### PR TITLE
Robustness Improvements

### DIFF
--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/AccountSnapshotTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/AccountSnapshotTest.java
@@ -68,11 +68,13 @@ public class AccountSnapshotTest {
                 fee
         );
         mobileCoinClient.submitTransaction(pendingTransaction.getTransaction());
-        waitForTransactionStatus(mobileCoinClient,
+        Transaction.Status status = waitForTransactionStatus(mobileCoinClient,
                 pendingTransaction.getTransaction());
 
-        AccountSnapshot snapshotAfter =
-                mobileCoinClient.getAccountSnapshot();
+        AccountSnapshot snapshotAfter;
+        do {
+            snapshotAfter = mobileCoinClient.getAccountSnapshot();
+        } while (snapshotAfter.getBlockIndex().compareTo(status.getBlockIndex()) < 0);
 
         Transaction.Status statusBefore =
                 snapshotBefore.getTransactionStatus(pendingTransaction.getTransaction());

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/PublicAddressTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/PublicAddressTest.java
@@ -181,7 +181,7 @@ public class PublicAddressTest {
                 fogReportId
         );
         if (!address.getViewKey().equals(key1) || !address.getSpendKey().equals(key2) ||
-                !address.getFogUri().equals(Environment.FOG_URI)) {
+                !address.getFogReportUri().equals(Environment.FOG_URI)) {
             Assert.fail("Getters must return valid keys");
         }
     }

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/UtilTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/UtilTest.java
@@ -8,8 +8,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.mobilecoin.lib.exceptions.AttestationException;
 import com.mobilecoin.lib.exceptions.InvalidFogResponse;
 import com.mobilecoin.lib.exceptions.InvalidReceiptException;
-import com.mobilecoin.lib.exceptions.InvalidTransactionException;
 import com.mobilecoin.lib.exceptions.NetworkException;
+import com.mobilecoin.lib.log.Logger;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -88,14 +88,14 @@ public class UtilTest {
     static Transaction.Status waitForTransactionStatus(
             @NonNull MobileCoinClient mobileCoinClient,
             @NonNull Transaction tx) throws TimeoutException, InterruptedException,
-            NetworkException, InvalidFogResponse, AttestationException,
-            InvalidTransactionException {
+            NetworkException, InvalidFogResponse, AttestationException {
         int txQueryTries = 0;
         Transaction.Status status;
         do {
             if (txQueryTries++ == STATUS_MAX_RETRIES) {
                 throw new TimeoutException();
             }
+            Logger.i(TAG, "Waiting 1 second for the transaction status");
             Thread.sleep(STATUS_CHECK_DELAY_MS);
             status = mobileCoinClient.getTransactionStatus(tx);
             Assert.assertTrue(status.getBlockIndex().compareTo(UnsignedLong.ZERO) > 0);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -249,7 +249,7 @@ public class MobileCoinClient {
         HashSet<FogUri> reportUris = new HashSet<>();
         try {
             if (recipient.hasFogInfo()) {
-                reportUris.add(new FogUri(recipient.getFogUri()));
+                reportUris.add(new FogUri(recipient.getFogReportUri()));
             }
             reportUris.add(new FogUri(getAccountKey().getFogReportUri()));
         } catch (InvalidUriException exception) {


### PR DESCRIPTION
### Motivation

Improve robustness by: 
* allowing to `prepareTransaction` to use cached `TxOuts` 
* parallelizing Reports & Rings fetching

### In this PR
* new method `prepareTransaction` for the `AccountSnapshot` class
* parallelizing Reports & Rings fetching
* caching `PublicAddress` fields

