### PR TITLE
Better attestation exception handling

### DIFF
--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedConsensusClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedConsensusClient.java
@@ -100,15 +100,7 @@ class AttestedConsensusClient extends AttestedClient {
                             try {
                                 return blockingRequest.clientTxPropose(encryptedRequest);
                             } catch (StatusRuntimeException exception) {
-                                if (exception.getStatus().getCode() == Status.Code.INTERNAL) {
-                                    AttestationException attestationException =
-                                            new AttestationException(exception.getStatus().getDescription(), exception);
-                                    Util.logException(TAG, attestationException);
-                                    attestReset();
-                                    throw attestationException;
-                                }
-                                Logger.w(TAG, "Unable to post transaction with consensus",
-                                        exception);
+                                attestReset();
                                 throw new NetworkException(exception);
                             }
                         }
@@ -116,6 +108,7 @@ class AttestedConsensusClient extends AttestedClient {
         try {
             return networkingCall.run();
         } catch (AttestationException | NetworkException | RuntimeException exception) {
+            Util.logException(TAG, exception);
             throw exception;
         } catch (Exception exception) {
             throw new IllegalStateException("BUG: unreachable code");

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
@@ -123,22 +123,17 @@ class AttestedLedgerClient extends AttestedClient {
                         Attest.Message response = decryptMessage(responseMessage);
                         return Ledger.GetOutputsResponse.parseFrom(response.getData());
                     } catch (StatusRuntimeException exception) {
-                        if (exception.getStatus().getCode() == Status.Code.INTERNAL) {
-                            attestReset();
-                            throw new AttestationException(exception.getStatus().getDescription(),
-                                    exception);
-                        }
+                        attestReset();
                         throw new NetworkException(exception);
                     } catch (InvalidProtocolBufferException exception) {
-                        InvalidFogResponse invalidFogResponse = new InvalidFogResponse(
-                                "GetOutputsResponse contains invalid data", exception);
-                        Util.logException(TAG, invalidFogResponse);
-                        throw invalidFogResponse;
+                        throw new InvalidFogResponse("GetOutputsResponse contains invalid data",
+                                exception);
                     }
                 });
         try {
             return networkingCall.run();
         } catch (InvalidFogResponse | AttestationException | NetworkException | RuntimeException exception) {
+            Util.logException(TAG, exception);
             throw exception;
         } catch (Exception exception) {
             throw new IllegalStateException("BUG: unreachable code");
@@ -176,26 +171,17 @@ class AttestedLedgerClient extends AttestedClient {
                         Attest.Message response = decryptMessage(encryptedResponse);
                         return Ledger.CheckKeyImagesResponse.parseFrom(response.getData().toByteArray());
                     } catch (InvalidProtocolBufferException exception) {
-                        InvalidFogResponse invalidFogResponse = new InvalidFogResponse(
+                        throw new InvalidFogResponse(
                                 "CheckKeyImagesResponse contains invalid data", exception);
-                        Util.logException(TAG, invalidFogResponse);
-                        throw invalidFogResponse;
                     } catch (StatusRuntimeException exception) {
-                        if (exception.getStatus().getCode() == Status.Code.INTERNAL) {
-                            attestReset();
-                            AttestationException attestationException =
-                                    new AttestationException(exception.getStatus().getDescription(),
-                                            exception);
-                            Util.logException(TAG, attestationException);
-                            throw attestationException;
-                        }
-                        Logger.w(TAG, "Unable to check key images", exception);
+                        attestReset();
                         throw new NetworkException(exception);
                     }
                 });
         try {
             return networkingCall.run();
         } catch (InvalidFogResponse | AttestationException | NetworkException | RuntimeException exception) {
+            Util.logException(TAG, exception);
             throw exception;
         } catch (Exception exception) {
             throw new IllegalStateException("BUG: unreachable code");

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
@@ -39,7 +39,7 @@ class AttestedViewClient extends AttestedClient {
     /**
      * Creates and initializes an instance of {@link AttestedViewClient}
      *
-     * @param uri      an address of the service
+     * @param uri           an address of the service
      * @param serviceConfig service configuration passed to MobileCoinClient
      */
     AttestedViewClient(@NonNull FogUri uri, @NonNull ClientConfig.Service serviceConfig) {
@@ -130,21 +130,14 @@ class AttestedViewClient extends AttestedClient {
                 Util.logException(TAG, invalidFogResponse);
                 throw invalidFogResponse;
             } catch (StatusRuntimeException exception) {
-                if (exception.getStatus().getCode() == Status.Code.INTERNAL) {
-                    AttestationException attestationException =
-                            new AttestationException(exception.getStatus().getDescription(),
-                                    exception);
-                    Util.logException(TAG, attestationException);
-                    attestReset();
-                    throw attestationException;
-                }
-                Logger.w(TAG, "Fog request() query has failed", exception);
+                attestReset();
                 throw new NetworkException(exception);
             }
         });
         try {
             return networkingCall.run();
         } catch (InvalidFogResponse | AttestationException | NetworkException | RuntimeException exception) {
+            Util.logException(TAG, exception);
             throw exception;
         } catch (Exception exception) {
             throw new IllegalStateException("BUG: unreachable code");

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
@@ -144,7 +144,6 @@ public class OwnedTxOut implements Serializable {
 
     @NonNull
     UnsignedLong getTxOutGlobalIndex() {
-        Logger.i(TAG, "Getting txOutGlobalIndex", null, txOutGlobalIndex);
         return txOutGlobalIndex;
     }
 
@@ -152,7 +151,6 @@ public class OwnedTxOut implements Serializable {
         if (keyImageHash == 0) {
             keyImageHash = Arrays.hashCode(keyImage);
         }
-        Logger.d(TAG, "Getting KeyImageHashCode", null, keyImageHash);
         return keyImageHash;
     }
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/util/NetworkingCall.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/util/NetworkingCall.java
@@ -46,7 +46,7 @@ public class NetworkingCall<T> {
 
     public static class DefaultRetryPolicy extends RetryPolicy {
         DefaultRetryPolicy() {
-            statusCodes = new int[]{403};
+            statusCodes = new int[]{403, 500};
             retryCount = 1;
         }
     }


### PR DESCRIPTION
### Motivation
Attested Clients encrypt/decrypt functions use an internal counter for each communication message, so if a network error prevents an encrypted message from being delivered, the local and remote internal counters will go out of sync and the attestation state needs to be reset.

### In this PR
* Clean up Attestation and Network Exceptions handling
* Re-attest and retry GRPC calls automatically for internal and permission denied errors
