### PR TITLE
Remove reportUri normalization

### DIFF
--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/AccountTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/AccountTest.java
@@ -186,8 +186,8 @@ public class AccountTest {
                 fogConfig.getFogReportId(),
                 fogConfig.getFogAuthoritySpki()
         );
-        byte[] serialized = accountKey1.toByteArray();
-        AccountKey accountKey2 = AccountKey.fromBytes(serialized);
+        byte[] serializedAccountKey = accountKey1.toByteArray();
+        AccountKey accountKey2 = AccountKey.fromBytes(serializedAccountKey);
         Assert.assertEquals("Serialized and restored accounts must be equal",
                 accountKey1,
                 accountKey2
@@ -206,12 +206,12 @@ public class AccountTest {
                     fogConfig.getFogReportId(),
                     fogConfig.getFogAuthoritySpki()
             );
-            byte[] serialized = accountKey.toByteArray();
-            AccountKey restored = AccountKey.fromBytes(serialized);
+            byte[] serializedAccountKey = accountKey.toByteArray();
+            AccountKey restoredAccountKey = AccountKey.fromBytes(serializedAccountKey);
             Assert.assertArrayEquals(
                     "Serialized roundtrip bytes must be equal",
-                    serialized,
-                    restored.toByteArray()
+                    serializedAccountKey,
+                    restoredAccountKey.toByteArray()
             );
         }
     }

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/AccountTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/AccountTest.java
@@ -127,15 +127,18 @@ public class AccountTest {
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
+
         AccountKey second = new AccountKey(key1_copy,
                 key2_copy,
                 fogUri,
                 fogConfig.getFogReportId(),
                 fogConfig.getFogAuthoritySpki()
         );
-        if (!first.equals(second)) {
-            Assert.fail("Public addresses with copied keys must be equal");
-        }
+        Assert.assertEquals("Public addresses with copied keys must be equal",
+                first,
+                second
+        );
+
         // swap keys to make objects not equal
         second = new AccountKey(key2,
                 key1,
@@ -143,41 +146,46 @@ public class AccountTest {
                 fogConfig.getFogReportId(),
                 fogConfig.getFogAuthoritySpki()
         );
-        if (first.equals(second)) {
-            Assert.fail("Different AccountKeys must not be equal");
-        }
+        Assert.assertNotEquals(
+                "Different AccountKeys must not be equal",
+                first,
+                second
+        );
+
         second = new AccountKey(key1,
                 key2,
                 differentFogUri,
                 fogConfig.getFogReportId(),
                 fogConfig.getFogAuthoritySpki()
         );
-        if (first.equals(second)) {
-            Assert.fail("Different AccountKeys must not be equal");
-        }
+        Assert.assertNotEquals(
+                "AccountKeys with different report uri must not be equal",
+                first,
+                second
+        );
+
         second = new AccountKey(key1,
                 key2,
                 fogUriWithPort,
                 fogConfig.getFogReportId(),
                 fogConfig.getFogAuthoritySpki()
         );
-
         if (!first.equivalent(second)) {
-            Assert.fail("AccountKeys with and without port in report uris must be " +
-                    "equivalent");
+            Assert.fail("AccountKeys with and without port must be equivalent");
         }
+
         second = new AccountKey(key1,
                 key2,
                 fogUriWithPort,
                 fogConfig.getFogReportId(),
                 fogConfig.getFogAuthoritySpki()
         );
-
-        if (first.equals(second)) {
-            Assert.fail("AccountKeys with and without port in report uris must not be equal");
-        }
+        Assert.assertNotEquals(
+                "AccountKeys with and without port must not be equal",
+                first,
+                second
+        );
     }
-
 
     @Test
     public void test_serialize() throws SerializationException, InvalidUriException {
@@ -198,7 +206,7 @@ public class AccountTest {
     public void test_serialize_integrity() throws SerializationException, InvalidUriException {
         Uri fogUri = Uri.parse("fog://some-test-uri");
         Uri fogUriWithPort = Uri.parse("fog://some-test-uri:443");
-        Uri[] fogUrisToTest = new Uri[] {fogUri, fogUriWithPort};
+        Uri[] fogUrisToTest = new Uri[]{fogUri, fogUriWithPort};
 
         for (Uri uri : fogUrisToTest) {
             AccountKey accountKey = AccountKey.createNew(

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/PublicAddressTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/PublicAddressTest.java
@@ -107,36 +107,47 @@ public class PublicAddressTest {
                 fogConfig.getFogAuthoritySpki(),
                 fogConfig.getFogReportId()
         );
-        if (first.hashCode() != second.hashCode()) {
-            Assert.fail("Equal objects must have equal hashes");
-        }
+        Assert.assertEquals(
+                "Equal objects must have equal hashes",
+                first.hashCode(),
+                second.hashCode()
+        );
+
         second = new PublicAddress(key2,
                 key1,
                 fogConfig.getFogUri(),
                 fogConfig.getFogAuthoritySpki(),
                 fogConfig.getFogReportId()
         );
-        if (first.hashCode() == second.hashCode()) {
-            Assert.fail("Different objects must have different hashes");
-        }
+        Assert.assertNotEquals(
+                "Different objects must have different hashes",
+                first.hashCode(),
+                second.hashCode()
+        );
+
         second = new PublicAddress(key1,
                 key2,
                 differentFogUri,
                 fogConfig.getFogAuthoritySpki(),
                 fogConfig.getFogReportId()
         );
-        if (first.hashCode() == second.hashCode()) {
-            Assert.fail("Different objects must have different hashes");
-        }
+        Assert.assertNotEquals(
+                "Different objects must have different hashes",
+                first.hashCode(),
+                second.hashCode()
+        );
+
         second = new PublicAddress(key1,
                 key2,
                 fogUriWithPort,
                 fogConfig.getFogAuthoritySpki(),
                 fogConfig.getFogReportId()
         );
-        if (first.hashCode() == second.hashCode()) {
-            Assert.fail("Hashes for equal objects must be equal as well");
-        }
+        Assert.assertNotEquals(
+                "PublicAddresses with different uri ports must have different hashes",
+                first.hashCode(),
+                second.hashCode()
+        );
     }
 
     @Test
@@ -164,9 +175,12 @@ public class PublicAddressTest {
                 fogConfig.getFogAuthoritySpki(),
                 fogConfig.getFogReportId()
         );
-        if (!first.equals(second)) {
-            Assert.fail("Public addresses with copied keys must be equal");
-        }
+        Assert.assertEquals(
+                "Public addresses with copied keys must be equal",
+                first,
+                second
+        );
+
         // swap keys to make objects not equal
         second = new PublicAddress(key2,
                 key1,
@@ -174,18 +188,36 @@ public class PublicAddressTest {
                 fogConfig.getFogAuthoritySpki(),
                 fogConfig.getFogReportId()
         );
-        if (first.equals(second)) {
-            Assert.fail("Different Public addresses must not be equal");
-        }
+        Assert.assertNotEquals(
+                "Different Public addresses must not be equal",
+                first,
+                second
+        );
+
+        second = new PublicAddress(key1,
+                key2,
+                fogUriWithPort,
+                fogConfig.getFogAuthoritySpki(),
+                fogConfig.getFogReportId()
+        );
+        Assert.assertNotEquals(
+                "Public addresses with different ports must not be equal",
+                first,
+                second
+        );
+
         second = new PublicAddress(key1,
                 key2,
                 differentFogUri,
                 fogConfig.getFogAuthoritySpki(),
                 fogConfig.getFogReportId()
         );
-        if (first.equals(second)) {
-            Assert.fail("Different Public addresses must not be equal");
-        }
+        Assert.assertNotEquals(
+                "PublicAddresses with different report uris must not be equal",
+                first,
+                second
+        );
+
         second = new PublicAddress(key1,
                 key2,
                 fogUriWithPort,
@@ -194,8 +226,7 @@ public class PublicAddressTest {
         );
 
         if (!first.equivalent(second)) {
-            Assert.fail("Public addresses with and without port in report uris must be " +
-                    "equivalent");
+            Assert.fail("Public addresses with and without port must be equivalent");
         }
     }
 
@@ -235,7 +266,7 @@ public class PublicAddressTest {
         Uri fogUri = Uri.parse("fog://some-test-uri");
         Uri fogUriWithPort = Uri.parse("fog://some-test-uri:443");
 
-        Uri[] fogUrisToTest = new Uri[] {fogUri, fogUriWithPort};
+        Uri[] fogUrisToTest = new Uri[]{fogUri, fogUriWithPort};
 
         for (Uri uri : fogUrisToTest) {
             PublicAddress address = new PublicAddress(key1,

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/PublicKeyTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/PublicKeyTest.java
@@ -59,9 +59,9 @@ public class PublicKeyTest {
 
     @Test
     public void test_serialize() throws SerializationException {
-        byte[] serialized = RistrettoPublic.fromBytes(pubKeyBytes).getKeyBytes();
+        byte[] serializedPubKey = RistrettoPublic.fromBytes(pubKeyBytes).getKeyBytes();
         Assert.assertArrayEquals(
-                serialized,
+                serializedPubKey,
                 pubKeyBytes
         );
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
@@ -37,7 +37,6 @@ public class OwnedTxOut implements Serializable {
     private final Date receivedBlockTimestamp;
     private Date spentBlockTimestamp;
     private UnsignedLong spentBlockIndex;
-    private boolean isSpent;
 
     private final BigInteger value;
     private final RistrettoPublic txOutPublicKey;
@@ -132,7 +131,7 @@ public class OwnedTxOut implements Serializable {
     }
 
     public synchronized boolean isSpent(@NonNull UnsignedLong atIndex) {
-        return isSpent && (spentBlockIndex.compareTo(atIndex) <= 0);
+        return (spentBlockIndex != null) && (spentBlockIndex.compareTo(atIndex) <= 0);
     }
 
     synchronized void setSpent(
@@ -142,7 +141,6 @@ public class OwnedTxOut implements Serializable {
         Logger.i(TAG, "Setting spent status", null,
                 "spentBlockIndex:", spentBlockIndex,
                 "spentBlockTimeStamp:", spentBlockTimestamp);
-        this.isSpent = true;
         this.spentBlockIndex = spentBlockIndex;
         this.spentBlockTimestamp = spentBlockTimestamp;
     }
@@ -164,8 +162,7 @@ public class OwnedTxOut implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         OwnedTxOut that = (OwnedTxOut) o;
-        return isSpent == that.isSpent &&
-                txOutGlobalIndex.equals(that.txOutGlobalIndex) &&
+        return txOutGlobalIndex.equals(that.txOutGlobalIndex) &&
                 receivedBlockIndex.equals(that.receivedBlockIndex) &&
                 spentBlockIndex.equals(that.spentBlockIndex) &&
                 value.equals(that.value) &&
@@ -176,8 +173,7 @@ public class OwnedTxOut implements Serializable {
     @Override
     public int hashCode() {
         int result = Objects.hash(txOutGlobalIndex, receivedBlockIndex,
-                spentBlockIndex, isSpent, value,
-                txOutPublicKey);
+                spentBlockIndex, value, txOutPublicKey);
         result = 31 * result + Arrays.hashCode(keyImage);
         return result;
     }


### PR DESCRIPTION
### Motivation

Remove `reportUri` normalization to use the exact input parameters for AccountKey and PublicAddress creation. This is needed to make sure serialization/deserialization does not change the serialized payload bytes.

Another consequence of this change is that equivalent `PublicAddresses` with implicit and explicit default ports will no longer be equal and will generate different b58 representations.
