### PR TITLE
Rename setConsensusAuthorization method

### DIFF
--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -776,7 +776,7 @@ public class MobileCoinClient {
     /**
      * Sets HTTP authorization username and password for consensus server requests.
      */
-    public void setConsensusAuthorization(@NonNull String username, @NonNull String password) {
+    public void setConsensusBasicAuthorization(@NonNull String username, @NonNull String password) {
         consensusClient.setAuthorization(
                 username,
                 password


### PR DESCRIPTION
### In this PR
Updates the setConsensusAuthorization method name to setConsensusBasicAuthorization, which is the name stated in the [ticket](https://mobilecoin.atlassian.net/browse/ANDROID-70).

