### PR TITLE
Fix balance drop bug

### DIFF
--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
@@ -203,12 +203,6 @@ class TxOutStore implements Serializable {
                     allTXOsRetrieved = true;
                 }
                 View.QueryResponse result = viewClient.request(searchKeys);
-                long blockCount = result.getHighestProcessedBlockCount();
-                synchronized (this) {
-                    viewBlockIndex = (blockCount != 0)
-                            ? UnsignedLong.fromLongBits(blockCount).sub(UnsignedLong.ONE)
-                            : UnsignedLong.ZERO;
-                }
                 Logger.d(TAG, "View Request completed", null,
                         "viewBlockIndex:", viewBlockIndex
                 );
@@ -286,6 +280,10 @@ class TxOutStore implements Serializable {
                         }
                         case View.TxOutSearchResultCode.NotFound_VALUE: {
                             allTXOsRetrieved = true;
+                            long blockCount = result.getHighestProcessedBlockCount();
+                            viewBlockIndex = (blockCount != 0)
+                                    ? UnsignedLong.fromLongBits(blockCount).sub(UnsignedLong.ONE)
+                                    : UnsignedLong.ZERO;
                             break;
                         }
                     }


### PR DESCRIPTION
### Motivation

`viewBlockIndex` is set before the TxOuts are processed which will return an incorrect balance in certain conditions.

### In this PR
move `viewBlockIndex` assignment after the Not_Found result code