### PR TITLE
Add final modifiers

### DIFF
--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
@@ -8,7 +8,7 @@ import com.mobilecoin.lib.exceptions.InvalidUriException;
 
 @VisibleForTesting
 public class Environment {
-    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.MOBILE_DEV;
+    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.ALPHA;
 
     static public MobileCoinClient makeFreshMobileCoinClient() throws InvalidUriException {
         AccountKey accountKey = TestKeysManager.getNextAccountKey();

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AccountActivity.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AccountActivity.java
@@ -17,7 +17,7 @@ import java.util.Set;
  * received and spent (if it was spent).
  * </pre>
  */
-public class AccountActivity {
+public final class AccountActivity {
     private final static String TAG = AccountActivity.class.getName();
     private final UnsignedLong blockCount;
     private final Set<OwnedTxOut> txOuts;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AccountKey.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AccountKey.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 /**
  * The {@code AccountKey} class represents an abstraction of view & spent private keys
  */
-public class AccountKey extends Native {
+public final class AccountKey extends Native {
     private final static String TAG = AccountKey.class.getName();
     private final Uri fogReportUri;
     private final String fogReportId;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AccountKeyDeriver.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AccountKeyDeriver.java
@@ -9,7 +9,7 @@ import com.mobilecoin.lib.exceptions.BadBip39EntropyException;
 /**
  * The {@link AccountKeyDeriver} is used to derive {@link AccountKey}s
  */
-class AccountKeyDeriver extends Native {
+final class AccountKeyDeriver extends Native {
     private final static String TAG = AccountKeyDeriver.class.getName();
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AccountSnapshot.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AccountSnapshot.java
@@ -2,6 +2,9 @@
 
 package com.mobilecoin.lib;
 
+import static com.mobilecoin.lib.MobileCoinClient.INPUT_FEE;
+import static com.mobilecoin.lib.MobileCoinClient.OUTPUT_FEE;
+
 import androidx.annotation.NonNull;
 
 import com.mobilecoin.lib.exceptions.AmountDecoderException;
@@ -25,13 +28,10 @@ import java.util.stream.Collectors;
 
 import fog_ledger.Ledger;
 
-import static com.mobilecoin.lib.MobileCoinClient.INPUT_FEE;
-import static com.mobilecoin.lib.MobileCoinClient.OUTPUT_FEE;
-
 /**
  * This class represents the Account's state at the specified block index
  */
-public class AccountSnapshot {
+public final class AccountSnapshot {
     private final static String TAG = AccountSnapshot.class.getName();
     private final UnsignedLong blockIndex;
     private final Set<OwnedTxOut> txOuts;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Amount.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Amount.java
@@ -15,7 +15,7 @@ import java.math.BigInteger;
  * Encapsulates the abstraction of a native Amount with a JNI link to control the native
  * counterpart.
  */
-class Amount extends Native {
+final class Amount extends Native {
     private final static String TAG = Amount.class.getName();
     private final MobileCoinAPI.Amount protoBufAmount;
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedConsensusClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedConsensusClient.java
@@ -23,7 +23,7 @@ import io.grpc.StatusRuntimeException;
 /**
  * Attested client for a consensus service
  */
-class AttestedConsensusClient extends AttestedClient {
+final class AttestedConsensusClient extends AttestedClient {
     private static final String TAG = AttestedConsensusClient.class.getName();
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
@@ -33,7 +33,7 @@ import io.grpc.StatusRuntimeException;
  * Attested client for a ledger service Attestation is done automatically by the parent class {@link
  * AttestedClient}
  */
-class AttestedLedgerClient extends AttestedClient {
+final class AttestedLedgerClient extends AttestedClient {
     private static final String TAG = AttestedLedgerClient.class.getName();
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
@@ -27,7 +27,7 @@ import io.grpc.StatusRuntimeException;
  * Attested client for a Fog View service Attestation is done automatically by the parent class
  * {@link AttestedClient}
  */
-class AttestedViewClient extends AttestedClient {
+final class AttestedViewClient extends AttestedClient {
     private static final String TAG = AttestedViewClient.class.getName();
 
     // The last event id serves as a cursor

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AuthInterceptor.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AuthInterceptor.java
@@ -18,7 +18,7 @@ import io.grpc.MethodDescriptor;
 /**
  * AuthInterceptor intercepts GRPC API calls to adds basic authorization header
  */
-class AuthInterceptor implements ClientInterceptor {
+final class AuthInterceptor implements ClientInterceptor {
 
     // metadata keys are case insensitive
     static final Metadata.Key<String> AUTHORIZATION_HEADER_KEY = Metadata.Key.of(

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Balance.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Balance.java
@@ -9,7 +9,7 @@ import java.math.BigInteger;
 /**
  * The {@code Balance} class represents the account balance
  */
-public class Balance {
+final public class Balance {
     private final static String TAG = Balance.class.getName();
     private final BigInteger amountPicoMob;
     private final UnsignedLong atBlock;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/BlockRange.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/BlockRange.java
@@ -11,7 +11,7 @@ import fog_common.FogCommon;
 /**
  * A class for representing a range of blocks [start, end)
  */
-class BlockRange implements Comparable<BlockRange> {
+final class BlockRange implements Comparable<BlockRange> {
     private final UnsignedLong start;
     private final UnsignedLong end;
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/BlockchainClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/BlockchainClient.java
@@ -15,7 +15,7 @@ import consensus_common.BlockchainAPIGrpc;
 import consensus_common.ConsensusCommon;
 import io.grpc.StatusRuntimeException;
 
-class BlockchainClient extends AnyClient {
+final class BlockchainClient extends AnyClient {
     private static final String TAG = BlockchainClient.class.getName();
     private static final BigInteger DEFAULT_TX_FEE = BigInteger.valueOf(10000000000L);
     private ConsensusCommon.LastBlockInfoResponse lastBlockInfo;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/ClientKexRng.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/ClientKexRng.java
@@ -7,7 +7,7 @@ import androidx.annotation.NonNull;
 import com.mobilecoin.lib.exceptions.KexRngException;
 import com.mobilecoin.lib.log.Logger;
 
-class ClientKexRng extends Native {
+final class ClientKexRng extends Native {
     private final static String TAG = ClientKexRng.class.getName();
 
     ClientKexRng(

--- a/android-sdk/src/main/java/com/mobilecoin/lib/CookieInterceptor.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/CookieInterceptor.java
@@ -18,7 +18,7 @@ import io.grpc.MethodDescriptor;
  * outgoing requests. Cookie persistence is required for session stickiness on the load balanced
  * services.
  */
-class CookieInterceptor implements ClientInterceptor {
+final class CookieInterceptor implements ClientInterceptor {
     private final static String TAG = CookieInterceptor.class.getName();
 
     // metadata keys are case insensitive

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DefaultFogQueryScalingStrategy.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DefaultFogQueryScalingStrategy.java
@@ -2,7 +2,7 @@
 
 package com.mobilecoin.lib;
 
-class DefaultFogQueryScalingStrategy implements FogQueryScalingStrategy {
+final class DefaultFogQueryScalingStrategy implements FogQueryScalingStrategy {
     private final static int MIN_QUERY_SIZE = 10;
     private final static int MAX_QUERY_SIZE = 200;
     private final static int MULTIPLIER = 3;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogBlockClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogBlockClient.java
@@ -25,7 +25,7 @@ import io.grpc.StatusRuntimeException;
  * Attested client for a ledger service Attestation is done automatically by the parent class {@link
  * AttestedClient}
  */
-class FogBlockClient extends AnyClient {
+final class FogBlockClient extends AnyClient {
     private static final String TAG = FogBlockClient.class.getName();
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogReportResponses.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogReportResponses.java
@@ -9,7 +9,7 @@ import androidx.annotation.NonNull;
 import com.mobilecoin.lib.exceptions.FogReportException;
 import com.mobilecoin.lib.log.Logger;
 
-class FogReportResponses extends Native {
+final class FogReportResponses extends Native {
     private static final String TAG = FogReportResponses.class.getName();
 
     FogReportResponses() throws FogReportException {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogReportsManager.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogReportsManager.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-class FogReportsManager {
+final class FogReportsManager {
     private final static String TAG = FogReportsManager.class.getName();
     private static final int MAX_FETCH_THREADS = 10;
     // timeout the network call if it's more than 5 minutes

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogResolver.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogResolver.java
@@ -7,7 +7,7 @@ import androidx.annotation.NonNull;
 import com.mobilecoin.lib.exceptions.FogReportException;
 import com.mobilecoin.lib.log.Logger;
 
-class FogResolver extends Native {
+final class FogResolver extends Native {
     private final static String TAG = FogResolver.class.getName();
 
     FogResolver(@NonNull FogReportResponses responses, @NonNull Verifier verifier) throws FogReportException {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 import fog_view.View;
 
-class FogSeed implements Serializable {
+final class FogSeed implements Serializable {
     private final static String TAG = FogSeed.class.getName();
 
     // Bump serial version and read/write code if fields change

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogUntrustedClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogUntrustedClient.java
@@ -22,7 +22,7 @@ import io.grpc.StatusRuntimeException;
  * Attested client for a ledger service Attestation is done automatically by the parent class {@link
  * AttestedClient}
  */
-class FogUntrustedClient extends AnyClient {
+final class FogUntrustedClient extends AnyClient {
     private static final String TAG = AttestedLedgerClient.class.getName();
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/KeyImage.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/KeyImage.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 /**
  * A 32-byte image of a private key `x`: I = x * H(x * G) = x * H(P).
  */
-public class KeyImage {
+final public class KeyImage {
     private final byte[] data;
 
     private KeyImage(@NonNull byte[] data) {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -434,44 +434,7 @@ public final class MobileCoinClient {
             throws InvalidFogResponse, AttestationException,
             NetworkException {
         Logger.i(TAG, "GetTransactionStatus call");
-        Ledger.CheckKeyImagesResponse keyImagesResponse =
-                ledgerClient.checkKeyImages(transaction.getKeyImages());
-        getTxOutStore().updateTxOutsSpentState(keyImagesResponse);
-        UnsignedLong ledgerBlockIndex =
-                UnsignedLong.fromLongBits(keyImagesResponse.getNumBlocks()).sub(UnsignedLong.ONE);
-        List<Ledger.KeyImageResult> keyImageResults = keyImagesResponse.getResultsList();
-        boolean txHasUnspentKeyImages = false;
-        for (Ledger.KeyImageResult keyImageResult : keyImageResults) {
-            if (keyImageResult.getKeyImageResultCode() != Ledger.KeyImageResultCode.Spent_VALUE) {
-                txHasUnspentKeyImages = true;
-                break;
-            }
-        }
-        if (!txHasUnspentKeyImages) {
-            Set<RistrettoPublic> outputPublicKeys = transaction.getOutputPublicKeys();
-            Ledger.TxOutResponse response =
-                    untrustedClient.fetchTxOuts(outputPublicKeys);
-            List<Ledger.TxOutResult> results = response.getResultsList();
-            boolean allTxOutsFound = true;
-            UnsignedLong outputBlockIndex = UnsignedLong.ZERO;
-            for (Ledger.TxOutResult txOutResult : results) {
-                if (txOutResult.getResultCode() != Ledger.TxOutResultCode.Found) {
-                    allTxOutsFound = false;
-                    break;
-                } else {
-                    UnsignedLong txOutBlockIndex =
-                            UnsignedLong.fromLongBits(txOutResult.getBlockIndex());
-                    if (outputBlockIndex.compareTo(txOutBlockIndex) < 0) {
-                        outputBlockIndex = txOutBlockIndex;
-                    }
-                }
-            }
-            if (allTxOutsFound) {
-                return Transaction.Status.ACCEPTED.atBlock(outputBlockIndex);
-            }
-            return Transaction.Status.FAILED.atBlock(ledgerBlockIndex);
-        }
-        return Transaction.Status.UNKNOWN.atBlock(ledgerBlockIndex);
+        return getAccountSnapshot().getTransactionStatus(transaction);
     }
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -52,7 +52,7 @@ import fog_ledger.Ledger;
  * Fog-enabled {@link AccountKey} is required to use {@code MobileCoinClient}.
  * </pre>
  */
-public class MobileCoinClient {
+public final class MobileCoinClient {
     static final BigInteger INPUT_FEE = BigInteger.valueOf(0L);
     static final BigInteger OUTPUT_FEE = BigInteger.valueOf(0L);
     private static final String TAG = MobileCoinClient.class.toString();

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
@@ -22,7 +22,7 @@ import fog_view.View;
 /**
  * A transaction output that belongs to a {@link AccountKey}
  */
-public final class OwnedTxOut implements Serializable {
+public class OwnedTxOut implements Serializable {
     private final static String TAG = OwnedTxOut.class.getName();
 
     // Bump serial version and read/write code if fields change

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
@@ -22,7 +22,7 @@ import fog_view.View;
 /**
  * A transaction output that belongs to a {@link AccountKey}
  */
-public class OwnedTxOut implements Serializable {
+public final class OwnedTxOut implements Serializable {
     private final static String TAG = OwnedTxOut.class.getName();
 
     // Bump serial version and read/write code if fields change

--- a/android-sdk/src/main/java/com/mobilecoin/lib/PaymentRequest.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/PaymentRequest.java
@@ -10,7 +10,7 @@ import com.mobilecoin.lib.log.Logger;
 
 import java.util.Objects;
 
-public class PaymentRequest {
+public final class PaymentRequest {
     private final static String TAG = PaymentRequest.class.getName();
     private final PublicAddress publicAddress;
     private final UnsignedLong value;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/PendingTransaction.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/PendingTransaction.java
@@ -12,7 +12,7 @@ import java.math.BigInteger;
  * Wrapper for the Transaction and Receipt objects obtained via {@link
  * MobileCoinClient#prepareTransaction(PublicAddress recipient, BigInteger amount, BigInteger fee)}
  */
-public class PendingTransaction {
+public final class PendingTransaction {
     private final static String TAG = PendingTransaction.class.getName();
     private final Transaction transaction;
     private final Receipt receipt;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/PrintableWrapper.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/PrintableWrapper.java
@@ -13,7 +13,7 @@ import com.mobilecoin.lib.exceptions.SerializationException;
 import com.mobilecoin.lib.log.Logger;
 import com.mobilecoin.lib.uri.MobUri;
 
-public class PrintableWrapper extends Native {
+public final class PrintableWrapper extends Native {
     private final static String TAG = PrintableWrapper.class.getName();
     private final PublicAddress publicAddress;
     private final PaymentRequest paymentRequest;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/PublicAddress.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/PublicAddress.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 /**
  * Represents account's public address to receive coins
  */
-public class PublicAddress extends Native {
+public final class PublicAddress extends Native {
     private static final String TAG = PublicAddress.class.getName();
     private final RistrettoPublic viewKey;
     private final RistrettoPublic spendKey;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Receipt.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Receipt.java
@@ -22,7 +22,7 @@ import java.math.BigInteger;
  * BigInteger)} Then shared with the recipient, so they can check the transaction status. Only the
  * recipient can use this receipt since it requires a recipient's key for decoding.
  */
-public class Receipt {
+public final class Receipt {
     private static final String TAG = Receipt.class.getName();
     static final int CONFIRMATION_NUMBER_LENGTH = 32;
     private final MobileCoinAPI.Receipt receiptBuf;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Report.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Report.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import report.ReportOuterClass;
 
-class Report extends Native {
+final class Report extends Native {
     private final static String TAG = Report.class.getName();
     private final long publicKeyExpiry;
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/ReportClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/ReportClient.java
@@ -21,7 +21,7 @@ import report.ReportOuterClass;
 /**
  * ReportClient
  */
-class ReportClient extends AnyClient {
+final class ReportClient extends AnyClient {
     private static final String TAG = ReportClient.class.getName();
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/ReportResponse.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/ReportResponse.java
@@ -9,7 +9,7 @@ import com.mobilecoin.lib.log.Logger;
 
 import java.util.List;
 
-class ReportResponse extends Native {
+final class ReportResponse extends Native {
     private final static String TAG = ReportResponse.class.getName();
     private final List<Report> reports;
     private final byte[][] chain;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/ResponderId.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/ResponderId.java
@@ -6,7 +6,7 @@ import android.net.Uri;
 
 import androidx.annotation.NonNull;
 
-class ResponderId extends Native {
+final class ResponderId extends Native {
 
     ResponderId(@NonNull Uri serviceUri) {
         init_jni(String.format(

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Ring.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Ring.java
@@ -11,7 +11,7 @@ import com.mobilecoin.lib.log.Logger;
 import java.util.ArrayList;
 import java.util.List;
 
-class Ring {
+final class Ring {
     private final static String TAG = Ring.class.getName();
     public final short realIndex;
     public final OwnedTxOut utxo;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/RistrettoPrivate.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/RistrettoPrivate.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
  * MobileCoin accounts consist of two RistrettoPrivate keys: view & spend
  * </pre>
  */
-public class RistrettoPrivate extends Native {
+public final class RistrettoPrivate extends Native {
     private final byte[] keyBytes;
 
     private RistrettoPrivate(long existingRustObj) {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/RistrettoPublic.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/RistrettoPublic.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
  * MobileCoin public addresses consist of two RistrettoPublic keys: view & spend
  * </pre>
  */
-public class RistrettoPublic extends Native implements Serializable {
+public final class RistrettoPublic extends Native implements Serializable {
     public static final int PUBLIC_KEY_SIZE = 32;
     private static final long serialVersionUID = 1L;
     private MobileCoinAPI.CompressedRistretto compressedRistretto;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/ServiceAPIManager.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/ServiceAPIManager.java
@@ -23,7 +23,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.stub.AbstractStub;
 import report.ReportAPIGrpc;
 
-class ServiceAPIManager {
+final class ServiceAPIManager {
     private static final String TAG = AttestedClient.class.toString();
     private static final int SHUTDOWN_TIMEOUT = 5000;
     private static final int MEGABYTE = 1024 * 1024;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Transaction.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Transaction.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class Transaction extends Native {
+public final class Transaction extends Native {
     private final static String TAG = Transaction.class.getName();
     private final MobileCoinAPI.Tx protoBufTx;
     private byte[] serializedBytes;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TransactionBuilder.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TransactionBuilder.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Locale;
 
 
-class TransactionBuilder extends Native {
+final class TransactionBuilder extends Native {
     private static final String TAG = TransactionBuilder.class.getName();
 
     TransactionBuilder(@NonNull FogResolver fogResolver) throws FogReportException {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOut.java
@@ -13,7 +13,7 @@ import com.mobilecoin.lib.log.Logger;
 
 import java.util.Objects;
 
-class TxOut extends Native {
+final class TxOut extends Native {
     private final static String TAG = TxOut.class.getName();
     private final MobileCoinAPI.TxOut protoBufTxOut;
     private final RistrettoPublic pubKey;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutMembershipProof.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutMembershipProof.java
@@ -7,7 +7,7 @@ import androidx.annotation.NonNull;
 import com.mobilecoin.lib.exceptions.SerializationException;
 import com.mobilecoin.lib.log.Logger;
 
-class TxOutMembershipProof extends Native {
+final class TxOutMembershipProof extends Native {
     private final static String TAG = TxOutMembershipProof.class.getName();
 
     TxOutMembershipProof(@NonNull byte[] protobufBytes) throws SerializationException {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
@@ -38,7 +38,7 @@ import fog_common.FogCommon;
 import fog_ledger.Ledger;
 import fog_view.View;
 
-class TxOutStore implements Serializable {
+final class TxOutStore implements Serializable {
     private static final String TAG = TxOutStore.class.getName();
 
     // Bump serial version and read/write code if fields change

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Util.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Util.java
@@ -18,7 +18,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-class Util extends Native {
+final class Util extends Native {
     private final static String TAG = Util.class.getName();
 
     static RistrettoPrivate recoverOnetimePrivateKey(

--- a/android-sdk/src/main/java/com/mobilecoin/lib/VerificationReport.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/VerificationReport.java
@@ -7,7 +7,7 @@ import androidx.annotation.NonNull;
 import com.mobilecoin.lib.exceptions.FogReportException;
 import com.mobilecoin.lib.log.Logger;
 
-class VerificationReport extends Native {
+final class VerificationReport extends Native {
     private final static String TAG = VerificationReport.class.getName();
 
     VerificationReport(@NonNull VerificationSignature signature,

--- a/android-sdk/src/main/java/com/mobilecoin/lib/VerificationSignature.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/VerificationSignature.java
@@ -7,7 +7,7 @@ import androidx.annotation.NonNull;
 import com.mobilecoin.lib.exceptions.FogReportException;
 import com.mobilecoin.lib.log.Logger;
 
-class VerificationSignature extends Native {
+final class VerificationSignature extends Native {
     private final static String TAG = VerificationSignature.class.getName();
 
     VerificationSignature(@NonNull byte[] sigBytes) throws FogReportException {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Verifier.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Verifier.java
@@ -12,7 +12,7 @@ import com.mobilecoin.lib.log.Logger;
  * Verifier is used for attestation connection verification.
  */
 
-public class Verifier extends Native {
+public final class Verifier extends Native {
     private static final String TAG = Verifier.class.getName();
 
     public Verifier() throws AttestationException {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/AmountDecoderException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/AmountDecoderException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class AmountDecoderException extends MobileCoinException {
+public final class AmountDecoderException extends MobileCoinException {
     public AmountDecoderException(@Nullable String message) {
         super(message);
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/AttestationException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/AttestationException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class AttestationException extends MobileCoinException {
+public final class AttestationException extends MobileCoinException {
 
     public AttestationException(@Nullable String message) {
         super(message);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/BadBip39EntropyException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/BadBip39EntropyException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class BadBip39EntropyException extends MobileCoinException {
+public final class BadBip39EntropyException extends MobileCoinException {
     public BadBip39EntropyException() {
         super();
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/BadEntropyException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/BadEntropyException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class BadEntropyException extends MobileCoinException {
+public final class BadEntropyException extends MobileCoinException {
     public BadEntropyException() {
         super();
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/BadMnemonicException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/BadMnemonicException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class BadMnemonicException extends MobileCoinException {
+public final class BadMnemonicException extends MobileCoinException {
     public BadMnemonicException() {
         super();
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/FeeRejectedException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/FeeRejectedException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class FeeRejectedException extends MobileCoinException {
+public final class FeeRejectedException extends MobileCoinException {
 
     public FeeRejectedException(@Nullable String message) {
         super(message);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/FogReportException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/FogReportException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class FogReportException extends MobileCoinException {
+public final class FogReportException extends MobileCoinException {
 
     public FogReportException() {
         super();

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/FragmentedAccountException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/FragmentedAccountException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class FragmentedAccountException extends MobileCoinException {
+public final class FragmentedAccountException extends MobileCoinException {
     public FragmentedAccountException(@Nullable String message) {
         super(message);
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InsufficientFundsException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InsufficientFundsException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class InsufficientFundsException extends MobileCoinException {
+public final class InsufficientFundsException extends MobileCoinException {
     InsufficientFundsException(@Nullable String message) {
         super(message);
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidFogResponse.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidFogResponse.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class InvalidFogResponse extends MobileCoinException {
+public final class InvalidFogResponse extends MobileCoinException {
     public InvalidFogResponse(@Nullable String message) {
         super(message);
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidReceiptException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidReceiptException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class InvalidReceiptException extends MobileCoinException {
+public final class InvalidReceiptException extends MobileCoinException {
     public InvalidReceiptException(@Nullable String message) {
         super(message);
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidTransactionException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidTransactionException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class InvalidTransactionException extends MobileCoinException {
+public final class InvalidTransactionException extends MobileCoinException {
     public InvalidTransactionException(@Nullable String message) {
         super(message);
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidUriException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidUriException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class InvalidUriException extends MobileCoinException {
+public final class InvalidUriException extends MobileCoinException {
     public InvalidUriException() {
     }
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/KexRngException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/KexRngException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class KexRngException extends MobileCoinException {
+public final class KexRngException extends MobileCoinException {
     public KexRngException() {
     }
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/NetworkException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/NetworkException.java
@@ -7,7 +7,7 @@ import androidx.annotation.Nullable;
 
 import io.grpc.StatusRuntimeException;
 
-public class NetworkException extends MobileCoinException {
+public final class NetworkException extends MobileCoinException {
     public final int statusCode;
 
     public NetworkException(int statusCode, @Nullable String message, @Nullable Throwable throwable) {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/SerializationException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/SerializationException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class SerializationException extends MobileCoinException {
+public final class SerializationException extends MobileCoinException {
     public SerializationException(@Nullable String message) {
         super(message);
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/TransactionBuilderException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/TransactionBuilderException.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.exceptions;
 
 import androidx.annotation.Nullable;
 
-public class TransactionBuilderException extends MobileCoinException {
+public final class TransactionBuilderException extends MobileCoinException {
     public TransactionBuilderException(@Nullable String message) {
         super(message);
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/uri/ConsensusUri.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/uri/ConsensusUri.java
@@ -4,11 +4,11 @@ package com.mobilecoin.lib.uri;
 
 import android.net.Uri;
 
-import com.mobilecoin.lib.exceptions.InvalidUriException;
-
 import androidx.annotation.NonNull;
 
-public class ConsensusUri extends MobileCoinUri {
+import com.mobilecoin.lib.exceptions.InvalidUriException;
+
+public final class ConsensusUri extends MobileCoinUri {
 
     public ConsensusUri(@NonNull Uri uri) throws InvalidUriException {
         super(uri, new ConsensusUriScheme());

--- a/android-sdk/src/main/java/com/mobilecoin/lib/uri/ConsensusUriScheme.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/uri/ConsensusUriScheme.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.uri;
 
 import androidx.annotation.NonNull;
 
-public class ConsensusUriScheme implements MobileCoinScheme {
+public final class ConsensusUriScheme implements MobileCoinScheme {
     @NonNull
     @Override
     public String secureScheme() {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/uri/FogUri.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/uri/FogUri.java
@@ -8,7 +8,7 @@ import androidx.annotation.NonNull;
 
 import com.mobilecoin.lib.exceptions.InvalidUriException;
 
-public class FogUri extends MobileCoinUri {
+public final class FogUri extends MobileCoinUri {
 
     public FogUri(@NonNull Uri uri) throws InvalidUriException {
         super(uri, new FogUriScheme());

--- a/android-sdk/src/main/java/com/mobilecoin/lib/uri/FogUriScheme.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/uri/FogUriScheme.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.uri;
 
 import androidx.annotation.NonNull;
 
-public class FogUriScheme implements MobileCoinScheme {
+public final class FogUriScheme implements MobileCoinScheme {
     @NonNull
     @Override
     public String secureScheme() {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/uri/MobUri.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/uri/MobUri.java
@@ -12,7 +12,7 @@ import com.mobilecoin.lib.log.Logger;
 import java.util.List;
 import java.util.Locale;
 
-public class MobUri {
+public final class MobUri {
     private final static String TAG = MobUri.class.getName();
     private final Uri uri;
     private final String payload;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/uri/MobUriScheme.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/uri/MobUriScheme.java
@@ -4,7 +4,7 @@ package com.mobilecoin.lib.uri;
 
 import androidx.annotation.NonNull;
 
-public class MobUriScheme implements MobileCoinScheme {
+public final class MobUriScheme implements MobileCoinScheme {
     @NonNull
     @Override
     public String secureScheme() {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/util/Err.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/util/Err.java
@@ -6,7 +6,7 @@ import androidx.annotation.Nullable;
 /**
  * This class represents failed state of @{link Result}.
  */
-public class Err<V, E> implements Result<V, E> {
+public final class Err<V, E> implements Result<V, E> {
     private final E error;
 
     Err(final E error) {

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,10 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.13'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,7 +16,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
-FROM gradle:6.5.1-jdk8
+FROM gradle:6.7.1-jdk8
 USER root
 ENV SDK_URL="https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip" \
     ANDROID_HOME="/usr/local/android-sdk" \
-    ANDROID_VERSION=29 \
-    ANDROID_BUILD_TOOLS_VERSION=29.0.3 \
+    ANDROID_VERSION=30 \
+    ANDROID_BUILD_TOOLS_VERSION=30.0.2 \
     PATH="$PATH":/usr/local/bin:/usr/local/google-cloud-sdk/bin \
     GCLOUD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-294.0.0-linux-x86_64.tar.gz"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/testApp/build.gradle
+++ b/testApp/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "29.0.3"
+    buildToolsVersion "30.0.2"
 
     defaultConfig {
         applicationId "com.mobilecoin.lib.app"


### PR DESCRIPTION
### Motivation

Add final modifiers to classes that are not supposed to be extended. This will improve performance, memory footprint, and better communicate to the SDK user how to use them.

### In this PR
* Add final modifiers [ANDROID-77](https://mobilecoin.atlassian.net/browse/ANDROID-77)
* Don't use cache in MobileCoinClient's calls (AccountSnapshot is used for cached operations) [ANDROID-84](https://mobilecoin.atlassian.net/browse/ANDROID-84)

### Future Work
* OwnedTxOut should be final, but cannot be so while it is used for testing with Mockito.