### PR TITLE
Create new interfaces for the MobileCoinClient functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ out/
 #  Uncomment the following line in case you need and you don't have the release build type files in your app
 # release/
 
+# Android Test DS Store
+android-sdk/src/androidTest/res/.DS_Store
+
 # Gradle files
 .gradle/
 build/

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinAccountClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinAccountClient.java
@@ -35,7 +35,7 @@ public interface MobileCoinAccountClient {
    */
   @Nullable
   AccountSnapshot getAccountSnapshot(UnsignedLong blockIndex) throws NetworkException,
-      InvalidFogResponse, AttestationException
+      InvalidFogResponse, AttestationException;
 
   /**
    * Retrieves {@code AccountKey}'s balance.

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinAccountClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinAccountClient.java
@@ -75,7 +75,7 @@ public interface MobileCoinAccountClient {
    * Retrieves the account activity.
    */
   @NonNull
-  AccountActivity getAccountActivity() throws NetworkException, InvalidFogResponse;
+  AccountActivity getAccountActivity() throws NetworkException, InvalidFogResponse, AttestationException;
 
   /**
    * Provides the {@link AccountKey} associated with this client instance.

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinAccountClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinAccountClient.java
@@ -30,8 +30,8 @@ public interface MobileCoinAccountClient {
    * Creates an account snapshot for the provided block index.
    *
    * @param blockIndex is the index of the last block to include TxOuts from
-   * @return {@link AccountSnapshot} or {@code null} if the {@code blockIndex} is higher than
-   * what fog currently at and not equals to {@link UnsignedLong#MAX_VALUE}
+   * @return {@link AccountSnapshot} or {@code null} if the {@code blockIndex} is higher than what
+   * fog currently at and not equals to {@link UnsignedLong#MAX_VALUE}
    */
   @Nullable
   AccountSnapshot getAccountSnapshot(UnsignedLong blockIndex) throws NetworkException,

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinAccountClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinAccountClient.java
@@ -1,0 +1,86 @@
+package com.mobilecoin.lib;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.mobilecoin.lib.exceptions.AttestationException;
+import com.mobilecoin.lib.exceptions.FogReportException;
+import com.mobilecoin.lib.exceptions.InsufficientFundsException;
+import com.mobilecoin.lib.exceptions.InvalidFogResponse;
+import com.mobilecoin.lib.exceptions.InvalidTransactionException;
+import com.mobilecoin.lib.exceptions.NetworkException;
+import com.mobilecoin.lib.exceptions.TransactionBuilderException;
+import java.math.BigInteger;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Handles interactions with the user's MobileCoin account.
+ *
+ * <p>>Makes requests to the MobileCoin blockchain to provide information regarding the account.
+ */
+public interface MobileCoinAccountClient {
+
+  /**
+   * Fetches the latest account snapshot.
+   */
+  @NonNull
+  AccountSnapshot getAccountSnapshot() throws NetworkException,
+      InvalidFogResponse, AttestationException;
+
+  /**
+   * Creates an account snapshot for the provided block index.
+   *
+   * @param blockIndex is the index of the last block to include TxOuts from
+   * @return {@link AccountSnapshot} or {@code null} if the {@code blockIndex} is higher than
+   * what fog currently at and not equals to {@link UnsignedLong#MAX_VALUE}
+   */
+  @Nullable
+  AccountSnapshot getAccountSnapshot(UnsignedLong blockIndex) throws NetworkException,
+      InvalidFogResponse, AttestationException
+
+  /**
+   * Retrieves {@code AccountKey}'s balance.
+   */
+  @NonNull
+  Balance getBalance() throws InvalidFogResponse, NetworkException, AttestationException;
+
+  /**
+   * Returns whether the defragmentation is required on the active account in order to send the
+   * specified amount
+   */
+  boolean requiresDefragmentation(@NonNull BigInteger amountToSend)
+      throws NetworkException, InvalidFogResponse, AttestationException,
+      InsufficientFundsException;
+
+  /**
+   * Defragments the user's account.
+   *
+   * <p>An account needs to be defragmented when an account balance consists of multiple coins and
+   * there are no big enough coins to successfully send the transaction.
+   *
+   * <p>If the account is too fragmented, it might be necessary to defragment the account more than
+   * once. However, wallet fragmentation is a rare occurrence since there is an internal mechanism
+   * to defragment the account during other operations.
+   *
+   * @param delegate monitors and controls the defragmentation process
+   */
+  void defragmentAccount(
+      @NonNull BigInteger amountToSend,
+      @NonNull DefragmentationDelegate delegate
+  ) throws InvalidFogResponse, AttestationException, NetworkException, InsufficientFundsException,
+      TransactionBuilderException, InvalidTransactionException,
+      FogReportException, TimeoutException;
+
+
+  /**
+   * Retrieves the account activity.
+   */
+  @NonNull
+  AccountActivity getAccountActivity() throws NetworkException, InvalidFogResponse;
+
+  /**
+   * Provides the {@link AccountKey} associated with this client instance.
+   */
+  @NonNull
+  AccountKey getAccountKey();
+
+}

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinNetworkManager.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinNetworkManager.java
@@ -1,0 +1,25 @@
+package com.mobilecoin.lib;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Handles authorization for network requests and internal networking processes.
+ */
+public interface MobileCoinNetworkManager {
+
+  /**
+   * Sets HTTP authorization username and password for FOG requests.
+   */
+  void setFogBasicAuthorization(@NonNull String username, @NonNull String password);
+
+  /**
+   * Sets HTTP authorization username and password for consensus server requests.
+   */
+  void setConsensusBasicAuthorization(@NonNull String username, @NonNull String password);
+
+  /**
+   * Attempts to gracefully shutdown internal networking and threading services This is a blocking
+   * call which in rare cases may take up to 10 seconds to complete.
+   */
+  void shutdown();
+}

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinNetworkManager.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinNetworkManager.java
@@ -22,4 +22,5 @@ public interface MobileCoinNetworkManager {
    * call which in rare cases may take up to 10 seconds to complete.
    */
   void shutdown();
+
 }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
@@ -48,7 +48,7 @@ public interface MobileCoinTransactionClient {
    * @param transaction a valid transaction object to submit (see {@link MobileCoinClient#prepareTransaction}}
    */
   void submitTransaction(@NonNull Transaction transaction)
-      throws InvalidTransactionException, NetworkException, AttestationException
+      throws InvalidTransactionException, NetworkException, AttestationException;
 
   /**
    * Checks the status of the transaction receipt. Recipient's key is required to decode
@@ -94,7 +94,7 @@ public interface MobileCoinTransactionClient {
    * Fetches or returns the cached minimum transaction fee.
    */
   @NonNull
-  public BigInteger getOrFetchMinimumTxFee() throws NetworkException
+  public BigInteger getOrFetchMinimumTxFee() throws NetworkException;
 
 
 }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
@@ -1,0 +1,101 @@
+package com.mobilecoin.lib;
+
+import androidx.annotation.NonNull;
+import com.mobilecoin.lib.exceptions.AttestationException;
+import com.mobilecoin.lib.exceptions.FeeRejectedException;
+import com.mobilecoin.lib.exceptions.FogReportException;
+import com.mobilecoin.lib.exceptions.FragmentedAccountException;
+import com.mobilecoin.lib.exceptions.InsufficientFundsException;
+import com.mobilecoin.lib.exceptions.InvalidFogResponse;
+import com.mobilecoin.lib.exceptions.InvalidReceiptException;
+import com.mobilecoin.lib.exceptions.InvalidTransactionException;
+import com.mobilecoin.lib.exceptions.NetworkException;
+import com.mobilecoin.lib.exceptions.TransactionBuilderException;
+import java.math.BigInteger;
+
+/** Enables clients to make MobileCoin transactions. */
+public interface MobileCoinTransactionClient {
+
+  /**
+   * Calculate the total transferable amount excluding all the required fees for such transfer.
+   */
+  @NonNull
+  BigInteger getTransferableAmount() throws NetworkException, InvalidFogResponse,
+      AttestationException;
+
+  /**
+   * Prepares a {@link PendingTransaction} to be executed.
+   *
+   * @param recipient {@link PublicAddress} of the recipient
+   * @param amount    transaction amount
+   * @param fee       transaction fee (see {@link MobileCoinClient#estimateTotalFee})
+   * @return {@link PendingTransaction} which encapsulates the {@link Transaction} and {@link
+   * Receipt} objects
+   */
+  @NonNull
+  PendingTransaction prepareTransaction(
+      @NonNull final PublicAddress recipient,
+      @NonNull final BigInteger amount,
+      @NonNull final BigInteger fee
+  ) throws InsufficientFundsException, FragmentedAccountException, FeeRejectedException,
+      InvalidFogResponse, AttestationException, NetworkException,
+      TransactionBuilderException, FogReportException;
+
+
+  /**
+   * Submits a {@link Transaction} to the consensus service.
+   *
+   * @param transaction a valid transaction object to submit (see {@link MobileCoinClient#prepareTransaction}}
+   */
+  void submitTransaction(@NonNull Transaction transaction)
+      throws InvalidTransactionException, NetworkException, AttestationException
+
+  /**
+   * Checks the status of the transaction receipt. Recipient's key is required to decode
+   * verification data, hence only the recipient of the transaction can verify receipts. Sender
+   * should use {@link MobileCoinClient#getTransactionStatus}.
+   *
+   * @param receipt provided by the transaction sender to the recipient
+   * @return {@link Receipt.Status}
+   */
+  @NonNull
+  Receipt.Status getReceiptStatus(@NonNull Receipt receipt)
+      throws InvalidFogResponse, NetworkException, AttestationException,
+      InvalidReceiptException;
+
+  /**
+   * Checks the status of the {@link Transaction}. Sender's key is required to decode verification
+   * data, hence only the sender of the transaction can verify it's status. Recipients should use
+   * {@link MobileCoinClient#getReceiptStatus}.
+   *
+   * @param transaction obtained from {@link MobileCoinClient#prepareTransaction}
+   * @return {@link Transaction.Status}
+   */
+  @NonNull
+  Transaction.Status getTransactionStatus(@NonNull Transaction transaction)
+      throws InvalidFogResponse, AttestationException,
+      NetworkException;
+
+  /**
+   * Estimates the minimum fee required to send a transaction with the specified amount. The account balance
+   * consists of multiple coins, if there are no big enough coins to successfully send the
+   * transaction {@link FragmentedAccountException} will be thrown. The account needs to be
+   * defragmented in order to send the specified amount. See
+   * {@link MobileCoinClient#defragmentAccount}.
+   *
+   * @param amount an amount value in picoMob
+   */
+  @NonNull
+  BigInteger estimateTotalFee(@NonNull BigInteger amount)
+      throws InsufficientFundsException, NetworkException, InvalidFogResponse,
+      AttestationException;
+
+  /**
+   * Fetches or returns the cached minimum transaction fee.
+   */
+  @NonNull
+  public BigInteger getOrFetchMinimumTxFee() throws NetworkException
+
+
+}
+

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
@@ -13,7 +13,9 @@ import com.mobilecoin.lib.exceptions.NetworkException;
 import com.mobilecoin.lib.exceptions.TransactionBuilderException;
 import java.math.BigInteger;
 
-/** Enables clients to make MobileCoin transactions. */
+/**
+ * Enables clients to make MobileCoin transactions.
+ */
 public interface MobileCoinTransactionClient {
 
   /**
@@ -77,11 +79,10 @@ public interface MobileCoinTransactionClient {
       NetworkException;
 
   /**
-   * Estimates the minimum fee required to send a transaction with the specified amount. The account balance
-   * consists of multiple coins, if there are no big enough coins to successfully send the
+   * Estimates the minimum fee required to send a transaction with the specified amount. The account
+   * balance consists of multiple coins, if there are no big enough coins to successfully send the
    * transaction {@link FragmentedAccountException} will be thrown. The account needs to be
-   * defragmented in order to send the specified amount. See
-   * {@link MobileCoinClient#defragmentAccount}.
+   * defragmented in order to send the specified amount. See {@link MobileCoinClient#defragmentAccount}.
    *
    * @param amount an amount value in picoMob
    */
@@ -94,8 +95,7 @@ public interface MobileCoinTransactionClient {
    * Fetches or returns the cached minimum transaction fee.
    */
   @NonNull
-  public BigInteger getOrFetchMinimumTxFee() throws NetworkException;
-
+  BigInteger getOrFetchMinimumTxFee() throws NetworkException;
 
 }
 


### PR DESCRIPTION
Motivation
Currently, there's no easy way for host apps to unit test the MobileCoinClient functionality because it can't be mocked (marked as final) and creating an instance requires complicated configuration.

In this PR
This PR extracts MobileCoinClient public methods into three interfaces. This enables host apps to implement test objects that implement the required interfaces in their unit tests.

Future Work
Continue extracting interfaces. Create similarly-named interfaces for the AccountSnapshot class, which basically does everything MobileCoinClient does, but without making network requests. 

Android-88
