### PR TITLE
Make Balance constructor public

### DIFF
--- a/android-sdk/src/main/java/com/mobilecoin/lib/Balance.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Balance.java
@@ -14,7 +14,7 @@ final public class Balance {
     private final BigInteger amountPicoMob;
     private final UnsignedLong atBlock;
 
-    Balance(
+    public Balance(
             @NonNull BigInteger amountPicoMob,
             @NonNull UnsignedLong atBlock
     ) {


### PR DESCRIPTION
### Motivation

To make the MobileCoinAccountClient interface more testable, it would be beneficial to allow implementations to construct their own Balance instances. Right now, these implementations can't construct the Balance object because the constructor is package-private.

### In this PR
This PR makes the Balance constructor public so that SDK clients can more easily test the MobileCoinAccountClient interface.
