### PR TITLE
Add config parameter to specify minimum fee TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2020-09-06
+### Changed
+- Added `minimumFeeCacheTTL` parameter to `ClientConfig` to control the duration of the minimum transaction fee caching period. The default value is set to 30 minutes.
+
 ## [1.1.0-pre2] - 2020-08-05
 ### Added
 - Dynamic Fees

--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '1.1.0-pre2'
+version '1.1.0'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/BlockchainClientTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/BlockchainClientTest.java
@@ -1,0 +1,47 @@
+package com.mobilecoin.lib;
+
+import com.mobilecoin.lib.uri.ConsensusUri;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import consensus_common.ConsensusCommon;
+
+public class BlockchainClientTest {
+    @Test
+    public void clientCachesLastBlockInfo() throws Exception {
+        BlockchainClient blockchainClient = new BlockchainClient(
+                new ConsensusUri(Environment.getTestFogConfig().getConsensusUri()),
+                Environment.getTestFogConfig().getClientConfig().consensus,
+                Duration.ofHours(1));
+        blockchainClient.setAuthorization(
+                Environment.getTestFogConfig().getUsername(),
+                Environment.getTestFogConfig().getPassword()
+        );
+        ConsensusCommon.LastBlockInfoResponse lastBlockInfoResponse1 =
+                blockchainClient.getOrFetchLastBlockInfo();
+        ConsensusCommon.LastBlockInfoResponse lastBlockInfoResponse2 =
+                blockchainClient.getOrFetchLastBlockInfo();
+        Assert.assertSame(lastBlockInfoResponse1, lastBlockInfoResponse2);
+    }
+
+    @Test
+    public void clientRespectsCacheTTL() throws Exception {
+        BlockchainClient blockchainClient = new BlockchainClient(
+                new ConsensusUri(Environment.getTestFogConfig().getConsensusUri()),
+                Environment.getTestFogConfig().getClientConfig().consensus,
+                Duration.ofSeconds(1));
+        blockchainClient.setAuthorization(
+                Environment.getTestFogConfig().getUsername(),
+                Environment.getTestFogConfig().getPassword()
+        );
+        ConsensusCommon.LastBlockInfoResponse lastBlockInfoResponse1 =
+                blockchainClient.getOrFetchLastBlockInfo();
+        Thread.sleep(1000);
+        ConsensusCommon.LastBlockInfoResponse lastBlockInfoResponse2 =
+                blockchainClient.getOrFetchLastBlockInfo();
+        Assert.assertNotSame(lastBlockInfoResponse1, lastBlockInfoResponse2);
+    }
+}

--- a/android-sdk/src/main/java/com/mobilecoin/lib/ClientConfig.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/ClientConfig.java
@@ -9,6 +9,7 @@ import com.mobilecoin.lib.exceptions.AttestationException;
 import com.mobilecoin.lib.log.LogAdapter;
 
 import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Set;
 
@@ -22,6 +23,8 @@ public final class ClientConfig {
     public Service consensus;
     public StorageAdapter storageAdapter;
     public LogAdapter logAdapter;
+    // default minimum fee cache TTL is 30 minutes
+    public Duration minimumFeeCacheTTL = Duration.ofMinutes(30);
 
     /**
      * Service Configuration

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -106,7 +106,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         this.cacheStorage = clientConfig.storageAdapter;
         FogUri normalizedFogUri = new FogUri(fogUri);
         this.blockchainClient = new BlockchainClient(new ConsensusUri(consensusUri),
-                clientConfig.consensus);
+                clientConfig.consensus, clientConfig.minimumFeeCacheTTL);
         this.viewClient = new AttestedViewClient(normalizedFogUri, clientConfig.fogView);
         this.ledgerClient = new AttestedLedgerClient(normalizedFogUri, clientConfig.fogLedger);
         this.consensusClient = new AttestedConsensusClient(new ConsensusUri(consensusUri),


### PR DESCRIPTION
### Motivation

The minimum transaction fee is not expected to change often so it makes sense to cache this value. And allow application developers to specify the duration of the cache lifetime.
The default cache lifetime value is set to 30 minutes.

### In this PR
* [ANDROID-97: Fee caching](https://mobilecoin.atlassian.net/browse/ANDROID-97)
