### PR TITLE
Allow plain text communication for insecure protocols

### DIFF
--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java
@@ -90,7 +90,7 @@ public class TestFogConfig {
                 testEnvironment.getName()
         ));
         final Uri consensusUri = Uri.parse(String.format(
-                "mc://consensus.%s.mobilecoin.com",
+                "mc://node1.%s.mobilecoin.com",
                 testEnvironment.getName()
         ));
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AnyClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AnyClient.java
@@ -36,11 +36,11 @@ import javax.net.ssl.TrustManagerFactory;
 import io.grpc.ManagedChannel;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 
-class AnyClient<MobUri extends MobileCoinUri> extends Native {
+class AnyClient extends Native {
     private final static String TAG = AttestedClient.class.getName();
     // How long to wait for the managed connection to gracefully shutdown in milliseconds
     private final static long MANAGED_CONNECTION_SHUTDOWN_TIME_LIMIT = 1000;
-    private final MobUri serviceUri;
+    private final MobileCoinUri serviceUri;
     private final ClientConfig.Service serviceConfig;
     private final GRPCServiceAPIManager grpcApiManager;
     private final RestServiceAPIManager restApiManager;
@@ -54,7 +54,7 @@ class AnyClient<MobUri extends MobileCoinUri> extends Native {
      *
      * @param uri a complete {@link Uri} of the service including port.
      */
-    protected AnyClient(@NonNull MobUri uri, @NonNull ClientConfig.Service serviceConfig) {
+    protected AnyClient(@NonNull MobileCoinUri uri, @NonNull ClientConfig.Service serviceConfig) {
         this.serviceUri = uri;
         this.serviceConfig = serviceConfig;
         this.grpcApiManager = new GRPCServiceAPIManager();
@@ -99,7 +99,7 @@ class AnyClient<MobUri extends MobileCoinUri> extends Native {
     }
 
     @NonNull
-    final MobUri getServiceUri() {
+    final MobileCoinUri getServiceUri() {
         return serviceUri;
     }
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AnyClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AnyClient.java
@@ -16,6 +16,7 @@ import com.mobilecoin.lib.network.services.ServiceAPIManager;
 import com.mobilecoin.lib.network.services.http.Requester;
 import com.mobilecoin.lib.network.services.http.clients.RestClient;
 import com.mobilecoin.lib.network.services.transport.Transport;
+import com.mobilecoin.lib.network.uri.MobileCoinUri;
 
 import java.io.IOException;
 import java.security.KeyManagementException;
@@ -35,11 +36,11 @@ import javax.net.ssl.TrustManagerFactory;
 import io.grpc.ManagedChannel;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 
-class AnyClient extends Native {
+class AnyClient<MobUri extends MobileCoinUri> extends Native {
     private final static String TAG = AttestedClient.class.getName();
     // How long to wait for the managed connection to gracefully shutdown in milliseconds
     private final static long MANAGED_CONNECTION_SHUTDOWN_TIME_LIMIT = 1000;
-    private final Uri serviceUri;
+    private final MobUri serviceUri;
     private final ClientConfig.Service serviceConfig;
     private final GRPCServiceAPIManager grpcApiManager;
     private final RestServiceAPIManager restApiManager;
@@ -53,7 +54,7 @@ class AnyClient extends Native {
      *
      * @param uri a complete {@link Uri} of the service including port.
      */
-    protected AnyClient(@NonNull Uri uri, @NonNull ClientConfig.Service serviceConfig) {
+    protected AnyClient(@NonNull MobUri uri, @NonNull ClientConfig.Service serviceConfig) {
         this.serviceUri = uri;
         this.serviceConfig = serviceConfig;
         this.grpcApiManager = new GRPCServiceAPIManager();
@@ -98,7 +99,7 @@ class AnyClient extends Native {
     }
 
     @NonNull
-    final Uri getServiceUri() {
+    final MobUri getServiceUri() {
         return serviceUri;
     }
 
@@ -115,7 +116,7 @@ class AnyClient extends Native {
             if (null == httpRequester) {
                 throw new IllegalArgumentException("HttpRequester was not properly set");
             }
-            restClient = new RestClient(getServiceUri(), httpRequester);
+            restClient = new RestClient(getServiceUri().getUri(), httpRequester);
         }
         return restClient;
     }
@@ -128,10 +129,14 @@ class AnyClient extends Native {
                 Logger.i(TAG, "Managed channel does not exist: creating one");
                 OkHttpChannelBuilder managedChannelBuilder = OkHttpChannelBuilder
                         .forAddress(
-                                serviceUri.getHost(),
-                                serviceUri.getPort()
-                        )
-                        .useTransportSecurity();
+                                serviceUri.getUri().getHost(),
+                                serviceUri.getUri().getPort()
+                        );
+                if (getServiceUri().isTlsEnabled()) {
+                    managedChannelBuilder.useTransportSecurity();
+                } else {
+                    managedChannelBuilder.usePlaintext();
+                }
                 Set<X509Certificate> trustRoots = getServiceConfig().getTrustRoots();
                 if (trustRoots != null && trustRoots.size() > 0) {
                     KeyStore caKeyStore = getTrustRootsKeyStore(trustRoots);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedClient.java
@@ -15,6 +15,7 @@ import com.mobilecoin.lib.log.Logger;
 import com.mobilecoin.lib.network.services.http.clients.RestClient;
 import com.mobilecoin.lib.network.services.transport.GRPCTransport;
 import com.mobilecoin.lib.network.services.transport.Transport;
+import com.mobilecoin.lib.network.uri.MobileCoinUri;
 
 import attest.Attest;
 import io.grpc.ManagedChannel;
@@ -23,7 +24,7 @@ import io.grpc.ManagedChannel;
  * Base class for attested communication with View/Ledger/Consensus servers
  */
 
-abstract class AttestedClient extends AnyClient {
+abstract class AttestedClient<MobUri extends MobileCoinUri> extends AnyClient<MobUri> {
     private final static String TAG = AttestedClient.class.getName();
     // How long to wait for the managed connection to gracefully shutdown in milliseconds
 
@@ -33,7 +34,7 @@ abstract class AttestedClient extends AnyClient {
      * @param uri           a complete {@link Uri} of the service including port.
      * @param serviceConfig service configuration passed to MobileCoinClient
      */
-    protected AttestedClient(@NonNull Uri uri, @NonNull ClientConfig.Service serviceConfig) {
+    protected AttestedClient(@NonNull MobUri uri, @NonNull ClientConfig.Service serviceConfig) {
         super(uri, serviceConfig);
     }
 
@@ -155,10 +156,11 @@ abstract class AttestedClient extends AnyClient {
      * @param serviceUri must include the port as well
      */
     @NonNull
-    protected byte[] attestStart(@NonNull Uri serviceUri) throws AttestationException {
+    protected byte[] attestStart(@NonNull MobUri mobileCoinUri) throws AttestationException {
         Logger.i(TAG, "FFI: attest_start call");
         try {
             ResponderId responderId;
+            Uri serviceUri = mobileCoinUri.getUri();
             String responderIdString = serviceUri.getQueryParameter("responder-id");
             if (responderIdString != null && !responderIdString.isEmpty()) {
                 responderId = ResponderId.fromStringRepresentation(responderIdString);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedClient.java
@@ -24,7 +24,7 @@ import io.grpc.ManagedChannel;
  * Base class for attested communication with View/Ledger/Consensus servers
  */
 
-abstract class AttestedClient<MobUri extends MobileCoinUri> extends AnyClient<MobUri> {
+abstract class AttestedClient extends AnyClient {
     private final static String TAG = AttestedClient.class.getName();
     // How long to wait for the managed connection to gracefully shutdown in milliseconds
 
@@ -34,7 +34,8 @@ abstract class AttestedClient<MobUri extends MobileCoinUri> extends AnyClient<Mo
      * @param uri           a complete {@link Uri} of the service including port.
      * @param serviceConfig service configuration passed to MobileCoinClient
      */
-    protected AttestedClient(@NonNull MobUri uri, @NonNull ClientConfig.Service serviceConfig) {
+    protected AttestedClient(@NonNull MobileCoinUri uri,
+                             @NonNull ClientConfig.Service serviceConfig) {
         super(uri, serviceConfig);
     }
 
@@ -156,16 +157,15 @@ abstract class AttestedClient<MobUri extends MobileCoinUri> extends AnyClient<Mo
      * @param serviceUri must include the port as well
      */
     @NonNull
-    protected byte[] attestStart(@NonNull MobUri mobileCoinUri) throws AttestationException {
+    protected byte[] attestStart(@NonNull MobileCoinUri serviceUri) throws AttestationException {
         Logger.i(TAG, "FFI: attest_start call");
         try {
             ResponderId responderId;
-            Uri serviceUri = mobileCoinUri.getUri();
-            String responderIdString = serviceUri.getQueryParameter("responder-id");
+            String responderIdString = serviceUri.getUri().getQueryParameter("responder-id");
             if (responderIdString != null && !responderIdString.isEmpty()) {
                 responderId = ResponderId.fromStringRepresentation(responderIdString);
             } else {
-                responderId = ResponderId.fromUri(serviceUri);
+                responderId = ResponderId.fromUri(serviceUri.getUri());
             }
             return attest_start(responderId);
         } catch (Exception exception) {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedConsensusClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedConsensusClient.java
@@ -23,7 +23,7 @@ import io.grpc.StatusRuntimeException;
 /**
  * Attested client for a consensus service
  */
-final class AttestedConsensusClient extends AttestedClient<ConsensusUri> {
+final class AttestedConsensusClient extends AttestedClient {
     private static final String TAG = AttestedConsensusClient.class.getName();
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedConsensusClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedConsensusClient.java
@@ -23,7 +23,7 @@ import io.grpc.StatusRuntimeException;
 /**
  * Attested client for a consensus service
  */
-final class AttestedConsensusClient extends AttestedClient {
+final class AttestedConsensusClient extends AttestedClient<ConsensusUri> {
     private static final String TAG = AttestedConsensusClient.class.getName();
 
     /**
@@ -35,7 +35,7 @@ final class AttestedConsensusClient extends AttestedClient {
      */
     AttestedConsensusClient(@NonNull ConsensusUri uri,
                             @NonNull ClientConfig.Service serviceConfig) {
-        super(uri.getUri(), serviceConfig);
+        super(uri, serviceConfig);
         Logger.i(TAG, "Created new AttestedConsensusClient", null,
                 "uri:", uri,
                 "verifier:", serviceConfig);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
@@ -33,7 +33,7 @@ import io.grpc.StatusRuntimeException;
  * Attested client for a ledger service Attestation is done automatically by the parent class {@link
  * AttestedClient}
  */
-final class AttestedLedgerClient extends AttestedClient<FogUri> {
+final class AttestedLedgerClient extends AttestedClient {
     private static final String TAG = AttestedLedgerClient.class.getName();
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
@@ -33,7 +33,7 @@ import io.grpc.StatusRuntimeException;
  * Attested client for a ledger service Attestation is done automatically by the parent class {@link
  * AttestedClient}
  */
-final class AttestedLedgerClient extends AttestedClient {
+final class AttestedLedgerClient extends AttestedClient<FogUri> {
     private static final String TAG = AttestedLedgerClient.class.getName();
 
     /**
@@ -44,7 +44,7 @@ final class AttestedLedgerClient extends AttestedClient {
      * @param serviceConfig service configuration passed to MobileCoinClient
      */
     AttestedLedgerClient(@NonNull FogUri uri, @NonNull ClientConfig.Service serviceConfig) {
-        super(uri.getUri(), serviceConfig);
+        super(uri, serviceConfig);
         Logger.i(TAG, "Created new AttestedLedgerClient", null,
                 "uri:", uri,
                 "verifier:", serviceConfig);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
@@ -27,7 +27,7 @@ import io.grpc.StatusRuntimeException;
  * Attested client for a Fog View service Attestation is done automatically by the parent class
  * {@link AttestedClient}
  */
-final class AttestedViewClient extends AttestedClient {
+final class AttestedViewClient extends AttestedClient<FogUri> {
     private static final String TAG = AttestedViewClient.class.getName();
 
     // The last event id serves as a cursor
@@ -43,7 +43,7 @@ final class AttestedViewClient extends AttestedClient {
      * @param serviceConfig service configuration passed to MobileCoinClient
      */
     AttestedViewClient(@NonNull FogUri uri, @NonNull ClientConfig.Service serviceConfig) {
-        super(uri.getUri(), serviceConfig);
+        super(uri, serviceConfig);
         Logger.i(TAG, "Created new AttestedViewClient", null,
                 "uri:", uri,
                 "verifier:", serviceConfig);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
@@ -27,7 +27,7 @@ import io.grpc.StatusRuntimeException;
  * Attested client for a Fog View service Attestation is done automatically by the parent class
  * {@link AttestedClient}
  */
-final class AttestedViewClient extends AttestedClient<FogUri> {
+final class AttestedViewClient extends AttestedClient {
     private static final String TAG = AttestedViewClient.class.getName();
 
     // The last event id serves as a cursor

--- a/android-sdk/src/main/java/com/mobilecoin/lib/BlockchainClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/BlockchainClient.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 import consensus_common.ConsensusCommon;
 import io.grpc.StatusRuntimeException;
 
-final class BlockchainClient extends AnyClient {
+final class BlockchainClient extends AnyClient<ConsensusUri> {
     private static final String TAG = BlockchainClient.class.getName();
     private static final BigInteger DEFAULT_TX_FEE = BigInteger.valueOf(10000000000L);
     private final Duration minimumFeeCacheTTL;
@@ -34,7 +34,7 @@ final class BlockchainClient extends AnyClient {
     BlockchainClient(@NonNull ConsensusUri uri,
                      @NonNull ClientConfig.Service serviceConfig,
                      @NonNull Duration minimumFeeCacheTTL) {
-        super(uri.getUri(), serviceConfig);
+        super(uri, serviceConfig);
         this.minimumFeeCacheTTL = minimumFeeCacheTTL;
     }
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/BlockchainClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/BlockchainClient.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 import consensus_common.ConsensusCommon;
 import io.grpc.StatusRuntimeException;
 
-final class BlockchainClient extends AnyClient<ConsensusUri> {
+final class BlockchainClient extends AnyClient {
     private static final String TAG = BlockchainClient.class.getName();
     private static final BigInteger DEFAULT_TX_FEE = BigInteger.valueOf(10000000000L);
     private final Duration minimumFeeCacheTTL;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogBlockClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogBlockClient.java
@@ -25,7 +25,7 @@ import io.grpc.StatusRuntimeException;
  * Attested client for a ledger service Attestation is done automatically by the parent class {@link
  * AttestedClient}
  */
-final class FogBlockClient extends AnyClient {
+final class FogBlockClient extends AnyClient<FogUri> {
     private static final String TAG = FogBlockClient.class.getName();
 
     /**
@@ -36,7 +36,7 @@ final class FogBlockClient extends AnyClient {
      * @param serviceConfig service configuration passed to MobileCoinClient
      */
     FogBlockClient(@NonNull FogUri uri, @NonNull ClientConfig.Service serviceConfig) {
-        super(uri.getUri(), serviceConfig);
+        super(uri, serviceConfig);
         Logger.i(TAG, "Created new FogBlockClient", null,
                 "uri:", uri,
                 "verifier:", serviceConfig);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogBlockClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogBlockClient.java
@@ -25,7 +25,7 @@ import io.grpc.StatusRuntimeException;
  * Attested client for a ledger service Attestation is done automatically by the parent class {@link
  * AttestedClient}
  */
-final class FogBlockClient extends AnyClient<FogUri> {
+final class FogBlockClient extends AnyClient {
     private static final String TAG = FogBlockClient.class.getName();
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogUntrustedClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogUntrustedClient.java
@@ -22,7 +22,7 @@ import io.grpc.StatusRuntimeException;
  * Attested client for a ledger service Attestation is done automatically by the parent class {@link
  * AttestedClient}
  */
-final class FogUntrustedClient extends AnyClient<FogUri> {
+final class FogUntrustedClient extends AnyClient {
     private static final String TAG = AttestedLedgerClient.class.getName();
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogUntrustedClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogUntrustedClient.java
@@ -22,7 +22,7 @@ import io.grpc.StatusRuntimeException;
  * Attested client for a ledger service Attestation is done automatically by the parent class {@link
  * AttestedClient}
  */
-final class FogUntrustedClient extends AnyClient {
+final class FogUntrustedClient extends AnyClient<FogUri> {
     private static final String TAG = AttestedLedgerClient.class.getName();
 
     /**
@@ -33,7 +33,7 @@ final class FogUntrustedClient extends AnyClient {
      * @param serviceConfig service configuration passed to MobileCoinClient
      */
     FogUntrustedClient(@NonNull FogUri uri, @NonNull ClientConfig.Service serviceConfig) {
-        super(uri.getUri(), serviceConfig);
+        super(uri, serviceConfig);
         Logger.i(TAG, "Created new FogUntrustedClient", null,
                 "uri:", uri,
                 "verifier:", serviceConfig);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/ReportClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/ReportClient.java
@@ -21,7 +21,7 @@ import report.ReportOuterClass;
 /**
  * ReportClient
  */
-final class ReportClient extends AnyClient {
+final class ReportClient extends AnyClient<FogUri> {
     private static final String TAG = ReportClient.class.getName();
 
     /**
@@ -30,7 +30,7 @@ final class ReportClient extends AnyClient {
      * @param uri address of the service.
      */
     ReportClient(@NonNull FogUri uri, @NonNull ClientConfig.Service serviceConfig) {
-        super(uri.getUri(), serviceConfig);
+        super(uri, serviceConfig);
     }
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/ReportClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/ReportClient.java
@@ -21,7 +21,7 @@ import report.ReportOuterClass;
 /**
  * ReportClient
  */
-final class ReportClient extends AnyClient<FogUri> {
+final class ReportClient extends AnyClient {
     private static final String TAG = ReportClient.class.getName();
 
     /**


### PR DESCRIPTION
### Motivation

Some types of testing require non-TLS communication.

### In this PR
* Enable plain text for `insecure-service_name://` protocols
* Use generics for specific service Uris
