### PR TITLE
Reset attested state on erros

### DIFF
--- a/android-sdk/src/main/java/com/mobilecoin/lib/AnyClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AnyClient.java
@@ -98,6 +98,10 @@ class AnyClient extends Native {
         return networkTransport;
     }
 
+    protected synchronized void resetNetworkTransport() {
+       networkTransport = null;
+    }
+
     @NonNull
     final MobileCoinUri getServiceUri() {
         return serviceUri;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedClient.java
@@ -208,6 +208,7 @@ abstract class AttestedClient extends AnyClient {
      */
     protected synchronized void attestReset() {
         Logger.i(TAG, "Reset attested state");
+        resetNetworkTransport();
         if (rustObj != 0) {
             try {
                 finalize_jni();

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedConsensusClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedConsensusClient.java
@@ -80,6 +80,7 @@ final class AttestedConsensusClient extends AttestedClient {
             Util.logException(TAG, networkException);
             throw networkException;
         } catch (Exception exception) {
+            attestReset();
             AttestationException attestationException = new AttestationException("Failed to" +
                     " attest the consensus connection", exception);
             Util.logException(TAG, attestationException);
@@ -110,6 +111,7 @@ final class AttestedConsensusClient extends AttestedClient {
         try {
             return networkingCall.run();
         } catch (AttestationException | NetworkException | RuntimeException exception) {
+            attestReset();
             Util.logException(TAG, exception);
             throw exception;
         } catch (Exception exception) {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
@@ -113,12 +113,12 @@ final class AttestedLedgerClient extends AttestedClient {
                 Ledger.GetOutputsRequest.newBuilder().addAllIndices(
                         indexes.stream().map(UnsignedLong::longValue).collect(Collectors.toList()))
                         .setMerkleRootBlock(merkleRootBlock).build();
-        Attest.Message message = encryptMessage(request);
         NetworkingCall<Ledger.GetOutputsResponse> networkingCall =
                 new NetworkingCall<>(() -> {
                     try {
                         FogMerkleProofService fogMerkleProofService =
                                 getAPIManager().getFogMerkleProofService(getNetworkTransport());
+                        Attest.Message message = encryptMessage(request);
                         Attest.Message responseMessage = fogMerkleProofService.getOutputs(message);
                         Attest.Message response = decryptMessage(responseMessage);
                         return Ledger.GetOutputsResponse.parseFrom(response.getData());
@@ -163,12 +163,12 @@ final class AttestedLedgerClient extends AttestedClient {
         Ledger.CheckKeyImagesRequest imagesRequest =
                 Ledger.CheckKeyImagesRequest.newBuilder().addAllQueries(keyImageQueries)
                         .build();
-        Attest.Message encryptedRequest = encryptMessage(imagesRequest);
         NetworkingCall<Ledger.CheckKeyImagesResponse> networkingCall =
                 new NetworkingCall<>(() -> {
                     try {
                         FogKeyImageService fogKeyImageService =
                                 getAPIManager().getFogKeyImageService(getNetworkTransport());
+                        Attest.Message encryptedRequest = encryptMessage(imagesRequest);
                         Attest.Message encryptedResponse = fogKeyImageService.checkKeyImages(encryptedRequest);
                         Attest.Message response = decryptMessage(encryptedResponse);
                         return Ledger.CheckKeyImagesResponse.parseFrom(response.getData().toByteArray());

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
@@ -116,10 +116,10 @@ final class AttestedViewClient extends AttestedClient {
         aadRequestBuilder.setStartFromUserEventId(lastKnownEventId);
         aadRequestBuilder.setStartFromBlockIndex(lastKnownBlockIndex);
 
-        Attest.Message message = encryptMessage(requestBuilder.build(), aadRequestBuilder.build());
         NetworkingCall<View.QueryResponse> networkingCall = new NetworkingCall<>(() -> {
             try {
                 FogViewService fogViewService = getAPIManager().getFogViewService(getNetworkTransport());
+                Attest.Message message = encryptMessage(requestBuilder.build(), aadRequestBuilder.build());
                 Attest.Message encryptedResponse = fogViewService.query(message);
                 Attest.Message response = decryptMessage(encryptedResponse);
                 View.QueryResponse queryResponse = View.QueryResponse.parseFrom(response.getData());

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
@@ -87,6 +87,7 @@ final class AttestedViewClient extends AttestedClient {
             Logger.w(TAG, "Failed to attest the fog view connection", exception);
             throw new NetworkException(exception);
         } catch (Exception exception) {
+            attestReset();
             AttestationException attestationException =
                     new AttestationException("Failed to attest the fog view connection", exception);
             Util.logException(TAG, attestationException);
@@ -103,7 +104,6 @@ final class AttestedViewClient extends AttestedClient {
     synchronized View.QueryResponse request(
             @Nullable List<byte[]> getTxosKexRngOutputs
     ) throws InvalidFogResponse, AttestationException, NetworkException {
-        FogViewService fogViewService = getAPIManager().getFogViewService(getNetworkTransport());
         View.QueryRequest.Builder requestBuilder = View.QueryRequest.newBuilder();
         View.QueryRequestAAD.Builder aadRequestBuilder = View.QueryRequestAAD.newBuilder();
         if (getTxosKexRngOutputs != null) {
@@ -119,6 +119,7 @@ final class AttestedViewClient extends AttestedClient {
         Attest.Message message = encryptMessage(requestBuilder.build(), aadRequestBuilder.build());
         NetworkingCall<View.QueryResponse> networkingCall = new NetworkingCall<>(() -> {
             try {
+                FogViewService fogViewService = getAPIManager().getFogViewService(getNetworkTransport());
                 Attest.Message encryptedResponse = fogViewService.query(message);
                 Attest.Message response = decryptMessage(encryptedResponse);
                 View.QueryResponse queryResponse = View.QueryResponse.parseFrom(response.getData());
@@ -138,6 +139,7 @@ final class AttestedViewClient extends AttestedClient {
         try {
             return networkingCall.run();
         } catch (InvalidFogResponse | AttestationException | NetworkException | RuntimeException exception) {
+            attestReset();
             Util.logException(TAG, exception);
             throw exception;
         } catch (Exception exception) {


### PR DESCRIPTION
### Motivation

An attested state may become invalid after errors, so it has to be reset.

### In this PR
* Reset attested state on errors
* Reset transport with invalid attestation

### Future Work
* Simplify re-attestation by abstracting out error processing