### PR TITLE
Decommission rng

### DIFF
--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
@@ -124,15 +124,15 @@ final class FogSeed implements Serializable {
         return utxos;
     }
 
-    public long getIngestInvocationId() {
+    long getIngestInvocationId() {
         return ingestInvocationId;
     }
 
-    public boolean isObsolete() {
+    boolean isObsolete() {
         return isObsolete;
     }
 
-    public void markObsolete() {
+    void markObsolete() {
         isObsolete = true;
     }
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
@@ -29,8 +29,8 @@ final class FogSeed implements Serializable {
     // Data that comes straight from fog.
     private byte[] nonce;
     private int rngVersion;
-    // True if the seed is decommissioned and all utxos have been retrieved.
-    private boolean isDeprecated;
+    // True if the seed is (a) decommissioned and (b) all utxos have been retrieved.
+    private boolean isObsolete;
     private UnsignedLong startBlock;
     private ArrayList<OwnedTxOut> utxos;
 
@@ -128,12 +128,12 @@ final class FogSeed implements Serializable {
         return ingestInvocationId;
     }
 
-    public boolean isDeprecated() {
-        return isDeprecated;
+    public boolean isObsolete() {
+        return isObsolete;
     }
 
-    public void deprecate() {
-        isDeprecated = true;
+    public void markObsolete() {
+        isObsolete = true;
     }
 
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
@@ -23,7 +23,6 @@ final class FogSeed implements Serializable {
     // Bump serial version and read/write code if fields change
     private static final long serialVersionUID = 1L;
 
-    private final long ingestInvocationId;
     // RNG
     private final ClientKexRng kexRng;
     // Data that comes straight from fog.
@@ -31,6 +30,7 @@ final class FogSeed implements Serializable {
     private int rngVersion;
     // True if the seed is (a) decommissioned and (b) all utxos have been retrieved.
     private boolean isObsolete;
+    private long ingestInvocationId;
     private UnsignedLong startBlock;
     private ArrayList<OwnedTxOut> utxos;
 
@@ -143,6 +143,7 @@ final class FogSeed implements Serializable {
         out.writeInt(rngVersion);
         out.writeObject(startBlock);
         out.writeObject(utxos);
+        out.writeObject(ingestInvocationId);
     }
 
     @SuppressWarnings("unchecked")
@@ -156,5 +157,6 @@ final class FogSeed implements Serializable {
         rngVersion = in.readInt();
         startBlock = (UnsignedLong) in.readObject();
         utxos = (ArrayList<OwnedTxOut>) in.readObject();
+        ingestInvocationId = in.readLong();
     }
 }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
@@ -22,11 +22,15 @@ final class FogSeed implements Serializable {
 
     // Bump serial version and read/write code if fields change
     private static final long serialVersionUID = 1L;
+
+    private final long ingestInvocationId;
     // RNG
     private final ClientKexRng kexRng;
     // Data that comes straight from fog.
     private byte[] nonce;
     private int rngVersion;
+    // True if the seed is decommissioned and all utxos have been retrieved.
+    private boolean isDeprecated;
     private UnsignedLong startBlock;
     private ArrayList<OwnedTxOut> utxos;
 
@@ -35,6 +39,7 @@ final class FogSeed implements Serializable {
             @NonNull View.RngRecord rngRecord
     ) throws KexRngException {
         Logger.i(TAG, "Initializing Fog Seed");
+        ingestInvocationId = rngRecord.getIngestInvocationId();
         nonce = rngRecord.getPubkey().getPubkey().toByteArray();
         rngVersion = rngRecord.getPubkey().getVersion();
         startBlock = UnsignedLong.fromLongBits(rngRecord.getStartBlock());
@@ -118,6 +123,19 @@ final class FogSeed implements Serializable {
     List<OwnedTxOut> getTxOuts() {
         return utxos;
     }
+
+    public long getIngestInvocationId() {
+        return ingestInvocationId;
+    }
+
+    public boolean isDeprecated() {
+        return isDeprecated;
+    }
+
+    public void deprecate() {
+        isDeprecated = true;
+    }
+
 
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.write(nonce.length);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
@@ -143,7 +143,7 @@ final class FogSeed implements Serializable {
         out.writeInt(rngVersion);
         out.writeObject(startBlock);
         out.writeObject(utxos);
-        out.writeObject(ingestInvocationId);
+        out.writeLong(ingestInvocationId);
     }
 
     @SuppressWarnings("unchecked")

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
@@ -197,7 +197,7 @@ final class TxOutStore implements Serializable {
             boolean allTXOsRetrieved = false;
             do {
                 List<byte[]> searchKeys = null;
-                if (seed != null && !seed.isDeprecated()) {
+                if (seed != null && !seed.isObsolete()) {
                     searchKeys = Arrays.asList(seed.getNextN(scalingStrategy.nextQuerySize()));
                 } else {
                     allTXOsRetrieved = true;
@@ -282,7 +282,7 @@ final class TxOutStore implements Serializable {
                         case View.TxOutSearchResultCode.NotFound_VALUE: {
                             allTXOsRetrieved = true;
                             if (isSeedDecommissioned(seed)) {
-                                seed.deprecate();
+                                seed.markObsolete();
                             }
                             long blockCount = result.getHighestProcessedBlockCount();
                             viewBlockIndex = (blockCount != 0)

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
@@ -4,7 +4,6 @@ package com.mobilecoin.lib;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.mobilecoin.lib.exceptions.AttestationException;
 import com.mobilecoin.lib.exceptions.InvalidFogResponse;
@@ -13,7 +12,10 @@ import com.mobilecoin.lib.exceptions.NetworkException;
 import com.mobilecoin.lib.exceptions.SerializationException;
 import com.mobilecoin.lib.log.Logger;
 import com.mobilecoin.lib.util.Hex;
-
+import fog_common.FogCommon;
+import fog_ledger.Ledger;
+import fog_view.View;
+import fog_view.View.DecommissionedIngestInvocation;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -34,10 +36,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import fog_common.FogCommon;
-import fog_ledger.Ledger;
-import fog_view.View;
-
 final class TxOutStore implements Serializable {
     private static final String TAG = TxOutStore.class.getName();
 
@@ -46,6 +44,8 @@ final class TxOutStore implements Serializable {
 
     // A map of nonce -> Seed.
     private HashMap<Integer, FogSeed> seeds;
+
+    private Set<Long> decommissionedIngestInvocationIds;
     // AccountKey.
     private AccountKey accountKey;
     // Block index reported from ledger server.
@@ -59,6 +59,7 @@ final class TxOutStore implements Serializable {
 
     TxOutStore(@NonNull AccountKey accountKey) {
         this.seeds = new HashMap<>();
+        this.decommissionedIngestInvocationIds = new HashSet<>();
         this.accountKey = accountKey;
         this.ledgerBlockIndex = UnsignedLong.ZERO;
         this.viewBlockIndex = UnsignedLong.ZERO;
@@ -196,12 +197,16 @@ final class TxOutStore implements Serializable {
             boolean allTXOsRetrieved = false;
             do {
                 List<byte[]> searchKeys = null;
-                if (seed != null) {
+                if (seed != null && !seed.isDeprecated()) {
                     searchKeys = Arrays.asList(seed.getNextN(scalingStrategy.nextQuerySize()));
                 } else {
                     allTXOsRetrieved = true;
                 }
                 View.QueryResponse result = viewClient.request(searchKeys);
+                for (DecommissionedIngestInvocation decommissionedIngestInvocation : result
+                    .getDecommissionedIngestInvocationsList()) {
+                  decommissionedIngestInvocationIds.add(decommissionedIngestInvocation.getIngestInvocationId());
+                }
                 for (FogCommon.BlockRange fogRange : result.getMissedBlockRangesList()) {
                     BlockRange range = new BlockRange(fogRange);
                     missedRanges.add(range);
@@ -276,6 +281,9 @@ final class TxOutStore implements Serializable {
                         }
                         case View.TxOutSearchResultCode.NotFound_VALUE: {
                             allTXOsRetrieved = true;
+                            if (isSeedDecommissioned(seed)) {
+                                seed.deprecate();
+                            }
                             long blockCount = result.getHighestProcessedBlockCount();
                             viewBlockIndex = (blockCount != 0)
                                     ? UnsignedLong.fromLongBits(blockCount).sub(UnsignedLong.ONE)
@@ -289,6 +297,10 @@ final class TxOutStore implements Serializable {
             } while (!allTXOsRetrieved);
         } while (pendingSeeds.size() > 0);
         return missedRanges;
+    }
+
+    private boolean isSeedDecommissioned(FogSeed seed) {
+      return decommissionedIngestInvocationIds.contains(seed.getIngestInvocationId());
     }
 
     void updateTxOutsSpentState(Ledger.CheckKeyImagesResponse keyImagesResponse) throws InvalidFogResponse {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
@@ -380,6 +380,7 @@ final class TxOutStore implements Serializable {
         out.writeObject(viewBlockIndex);
         out.writeObject(ledgerTotalTxCount);
         out.writeObject(seeds);
+        out.writeObject(decommissionedIngestInvocationIds);
         out.writeObject(recoveredTxOuts);
     }
 
@@ -390,6 +391,7 @@ final class TxOutStore implements Serializable {
         viewBlockIndex = (UnsignedLong) in.readObject();
         ledgerTotalTxCount = (UnsignedLong) in.readObject();
         seeds = (HashMap<Integer, FogSeed>) in.readObject();
+        decommissionedIngestInvocationIds = (Set<Long>) in.readObject();
         recoveredTxOuts = new ConcurrentLinkedQueue<>();
     }
 }


### PR DESCRIPTION
### Motivation

The SDK uses an RNG supplied by Fog Ingest to generate private txo search keys. The RNG seeds are specific to a given enclave, so when we upgrade to a new enclave the RNGs associated with the old enclave will not produce new search keys. These old RNGs are said to be "decommissioned," and the SDK should no longer generate search keys from them once we've gotten the last txo associated with the seed. 

The SDK didn't necessarily need to implement this functionality up until this point because there weren't a lot of decommissioned RNGs. However, as txos grow over time, querying decommissioned RNGs would negatively impact performance for no benefit to the user. As such, we're implementing this behavior now.

### In this PR
Adds a field to FogSeed called "isObsolete" that signifies if the seed is (a) decommissioned and (b) has had all of its txos retrieved. If the FogSeed is obsolete, then we won't use it to make Fog ingest queries.

Fixes [Decommission RNGs on Android](https://app.asana.com/0/1200318482173758/1200318482173797/f)


### Testing
Eran ran the Fog conformance tests, and confirmed that the tests passed. I also added logs in the new logic branches, and Eran confirmed that he saw those logs, which indicates that the new logic is being executed. 

### Future Work
* Non goal: Fix attestation issue
* Refactor TxOutStore logic to be more modular.
* Implement Parcelable serialization instead of Serializable 

