### PR TITLE
Update Network Robustness to use the "gw" API prefix

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.google.protobuf'
+apply from: 'publish.gradle'
 
 def grpcVersion = "1.38.0"
 def protobufVersion = "3.17.0"

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
@@ -5,6 +5,7 @@ package com.mobilecoin.lib;
 import androidx.annotation.VisibleForTesting;
 
 import com.mobilecoin.lib.exceptions.InvalidUriException;
+import com.mobilecoin.lib.network.TransportProtocol;
 
 @VisibleForTesting
 public class Environment {
@@ -35,6 +36,7 @@ public class Environment {
                 fogConfig.getUsername(),
                 fogConfig.getPassword()
         );
+        mobileCoinClient.setTransportProtocol(TransportProtocol.forHTTP(new SimpleRequester()));
         return mobileCoinClient;
     }
 

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/MobileCoinClientTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/MobileCoinClientTest.java
@@ -2,6 +2,7 @@
 
 package com.mobilecoin.lib;
 
+import static com.mobilecoin.lib.Environment.getTestFogConfig;
 import static com.mobilecoin.lib.UtilTest.waitForReceiptStatus;
 import static com.mobilecoin.lib.UtilTest.waitForTransactionStatus;
 
@@ -168,7 +169,7 @@ public class MobileCoinClientTest {
     @Test
     public void test_attestation_must_fail() throws NetworkException, InvalidFogResponse,
             InvalidUriException {
-        TestFogConfig fogConfig = Environment.getTestFogConfig();
+        TestFogConfig fogConfig = getTestFogConfig();
         ClientConfig clientConfig = fogConfig.getClientConfig();
         // change fog verifier to make balance call fail
         clientConfig.fogView = clientConfig.consensus;
@@ -193,7 +194,7 @@ public class MobileCoinClientTest {
     @Test
     public void test_bad_trust_root_must_fail() throws InvalidFogResponse,
             InvalidUriException, AttestationException {
-        TestFogConfig fogConfig = Environment.getTestFogConfig();
+        TestFogConfig fogConfig = getTestFogConfig();
         ClientConfig clientConfig = fogConfig.getClientConfig();
         // change fog verifier to make balance call fail
         byte[] certificateBytes = Base64.decode(wrongTrustRootBase64, Base64.DEFAULT);
@@ -376,7 +377,7 @@ public class MobileCoinClientTest {
         final BigInteger MINIMUM_TX_FEE = coinSourceClient.getOrFetchMinimumTxFee();
         final BigInteger FRAGMENT_AMOUNT = MINIMUM_TX_FEE.multiply(BigInteger.TEN);
 
-        TestFogConfig fogConfig = Environment.getTestFogConfig();
+        TestFogConfig fogConfig = getTestFogConfig();
         // 1. Create a new fragmented account
         AccountKey fragmentedAccount = AccountKey.createNew(
                 fogConfig.getFogUri(),
@@ -576,7 +577,7 @@ public class MobileCoinClientTest {
             AttestationException, FogReportException, TransactionBuilderException,
             FragmentedAccountException, FeeRejectedException, InterruptedException,
             InvalidTransactionException, TimeoutException {
-        TestFogConfig fogConfig = Environment.getTestFogConfig();
+        TestFogConfig fogConfig = getTestFogConfig();
         AccountKey recipientAccount = TestKeysManager.getNextAccountKey();
         // remove fog info from the public address
         PublicAddress addressWithFog = recipientAccount.getPublicAddress();

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java
@@ -26,11 +26,8 @@ public class TestFogConfig {
     private final byte[] fogAuthoritySpki;
     private final String fogReportId;
 
-    private static final String TEST_DEV_USERNAME = "REPLACE_TEST_DEV_USER_STRING";
-    private static final String TEST_DEV_PASSWORD = "REPLACE_TEST_DEV_PASSWORD_STRING";
-
-    private static final String TEST_NET_USERNAME = "REPLACE_TEST_NET_USER_STRING";
-    private static final String TEST_NET_PASSWORD = "REPLACE_TEST_NET_PASSWORD_STRING";
+    private static final String TEST_USERNAME = "REPLACE_TEST_DEV_USER_STRING";
+    private static final String TEST_PASSWORD = "REPLACE_TEST_DEV_PASSWORD_STRING";
 
     private static final byte[] mobiledevFogAuthoritySpki = Base64.decode("MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAxABZ75QZv9uH9/E823VTTmpWiOiehoqksZMqsDARqYdDexAQb1Y+qyT6Hlp5QMUHQlkomFKLnhe/0+wxZ1/uTqnhy2FRhrlclpOvczT10Smcx9RkKACpxCW095MWxeFwtMmLpqkXfl4KeMptxdHRASHuLlKL+FXwOqKw3J2nw5q2DpBsg1ONkdW4m55ZFdimX3M7T/Wur5WlB+ntBpKFU/5T+rdD3OUm/tExbYk7C58XmYW08TnFR9JOMekFZMmTfl5d1ee3koyzz225QfNEupUJDVMXcg4whp826arxQIXrM2DfgwZnxFqS617dNsOPNjIoAYSEFPczYTw9WHR7O3UISnYwYvCsXxGwLZLXFkgUBM5GKItvEHDbUh3C7ZjyM51A04EJg47G3nI1A6q9EVnmwGaZFxq8bJAzosn5zaSrbUA25hRff25C4BYNjydBI133PjSflLaGjnJYPruLO4XpzB3wszqKm3tiWN39sgC4sMWZfSlxlWox3SzY2XVl8Q9RqMO8LMUPNhwmTfpEXDW5+NqH+vMiH9UmnsiEwybFche4sE23NJTeO2Xytt55VfoD2Gidte/Sqt5AJUPu6nfK8QloOCZ1N99MrpWpcZPHittqaYHZ5lWXHKthp/im672hXPl8bNxMUoREqomZdD9mdj/P6w9zFeTkr7P9XQUCAwEAAQ==", Base64.DEFAULT);
     private static final byte[] alphaFogAuthoritySpki = Base64.decode("MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAyFOockvCEc9TcO1NvsiUfFVzvtDsR64UIRRUl3tBM2Bh8KBA932/Up86RtgJVnbslxuUCrTJZCV4dgd5hAo/mzuJOy9lAGxUTpwWWG0zZJdpt8HJRVLX76CBpWrWEt7JMoEmduvsCR8q7WkSNgT0iIoSXgT/hfWnJ8KGZkN4WBzzTH7hPrAcxPrzMI7TwHqUFfmOX7/gc+bDV5ZyRORrpuu+OR2BVObkocgFJLGmcz7KRuN7/dYtdYFpiKearGvbYqBrEjeo/15chI0Bu/9oQkjPBtkvMBYjyJPrD7oPP67i0ZfqV6xCj4nWwAD3bVjVqsw9cCBHgaykW8ArFFa0VCMdLy7UymYU5SQsfXrw/mHpr27Pp2Z0/7wpuFgJHL+0ARU48OiUzkXSHX+sBLov9X6f9tsh4q/ZRorXhcJi7FnUoagBxewvlfwQfcnLX3hp1wqoRFC4w1DC+ki93vIHUqHkNnayRsf1n48fSu5DwaFfNvejap7HCDIOpCCJmRVR8mVuxi6jgjOUa4Vhb/GCzxfNIn5ZYym1RuoE0TsFO+TPMzjed3tQvG7KemGFz3pQIryb43SbG7Q+EOzIigxYDytzcxOO5Jx7r9i+amQEiIcjBICwyFoEUlVJTgSpqBZGNpznoQ4I2m+uJzM+wMFsinTZN3mp4FU5UHjQsHKG+ZMCAwEAAQ==", Base64.DEFAULT);
@@ -96,16 +93,16 @@ public class TestFogConfig {
 
         switch (testEnvironment) {
             case MOBILE_DEV:
-                return new TestFogConfig(fogUri, consensusUri, TEST_DEV_USERNAME,
-                        TEST_DEV_PASSWORD, getDevClientConfig(),
+                return new TestFogConfig(fogUri, consensusUri, TEST_USERNAME,
+                        TEST_PASSWORD, getDevClientConfig(),
                         mobiledevFogAuthoritySpki, "");
             case ALPHA:
-                return new TestFogConfig(fogUri, consensusUri, TEST_DEV_USERNAME,
-                        TEST_DEV_PASSWORD, getDevClientConfig(),
+                return new TestFogConfig(fogUri, consensusUri, TEST_USERNAME,
+                        TEST_PASSWORD, getDevClientConfig(),
                         alphaFogAuthoritySpki, "");
             case TEST_NET:
-                return new TestFogConfig(fogUri, consensusUri, TEST_NET_USERNAME,
-                        TEST_NET_PASSWORD, getTestNetClientConfig(),
+                return new TestFogConfig(fogUri, consensusUri, TEST_USERNAME,
+                        TEST_PASSWORD, getTestNetClientConfig(),
                         testNetFogAuthoritySpki, "");
 
         }

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TestKeysManager.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TestKeysManager.java
@@ -31,6 +31,13 @@ class TestKeysManager {
         return strings.toArray(new String[0]);
     }
 
+    static int getTotalTestKeysCount() {
+        if (Environment.CURRENT_TEST_ENV == Environment.TestEnvironment.TEST_NET) {
+            return testNetMnemonics.length;
+        }
+        return devNetRootEntropies.length;
+    }
+
     static AccountKey getNextAccountKey() {
         TestFogConfig fogConfig = Environment.getTestFogConfig();
         switch (Environment.CURRENT_TEST_ENV) {

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TxOutStoreTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TxOutStoreTest.java
@@ -129,7 +129,8 @@ public class TxOutStoreTest {
         // add two small ranges to check
         Set<BlockRange> fakeFogMisses = new HashSet<>(Arrays.asList(new BlockRange(txoBlock,
                         txoBlock.add(UnsignedLong.ONE)),
-                new BlockRange(25, 50)));
+                new BlockRange(status.getBlockIndex(),
+                        status.getBlockIndex().add(UnsignedLong.TEN))));
         Set<OwnedTxOut> records = store.fetchFogMisses(
                 fakeFogMisses,
                 blockClient

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
@@ -166,7 +166,7 @@ public class OwnedTxOut implements Serializable {
         OwnedTxOut that = (OwnedTxOut) o;
         return txOutGlobalIndex.equals(that.txOutGlobalIndex) &&
                 receivedBlockIndex.equals(that.receivedBlockIndex) &&
-                spentBlockIndex.equals(that.spentBlockIndex) &&
+                Objects.equals(spentBlockIndex, that.spentBlockIndex) &&
                 value.equals(that.value) &&
                 txOutPublicKey.equals(that.txOutPublicKey) &&
                 Arrays.equals(keyImage, that.keyImage);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestAttestedService.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestAttestedService.java
@@ -21,7 +21,7 @@ public class RestAttestedService extends RestService implements AttestedService 
     public Attest.AuthMessage auth(Attest.AuthMessage authMessage) {
             try {
                 byte[] responseData = getRestClient().makeRequest(
-                        SERVICE_NAME + "/" + "Auth",
+                        PREFIX + SERVICE_NAME + "/" + "Auth",
                         authMessage.toByteArray()
                 );
                 return Attest.AuthMessage.parseFrom(responseData);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestBlockchainService.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestBlockchainService.java
@@ -22,7 +22,7 @@ public class RestBlockchainService extends RestService implements BlockchainServ
     public ConsensusCommon.LastBlockInfoResponse getLastBlockInfo(Empty request) {
         try {
             byte[] responseData = getRestClient().makeRequest(
-                    SERVICE_NAME + "/" + "GetLastBlockInfo",
+                    PREFIX + SERVICE_NAME + "/" + "GetLastBlockInfo",
                     request.toByteArray()
             );
             return ConsensusCommon.LastBlockInfoResponse.parseFrom(responseData);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestConsensusClientService.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestConsensusClientService.java
@@ -22,7 +22,7 @@ public class RestConsensusClientService extends RestService implements Consensus
     public ConsensusCommon.ProposeTxResponse clientTxPropose(Attest.Message request) {
         try {
             byte[] responseData = getRestClient().makeRequest(
-                    SERVICE_NAME + "/" + "ClientTxPropose",
+                    PREFIX + SERVICE_NAME + "/" + "ClientTxPropose",
                     request.toByteArray()
             );
             return ConsensusCommon.ProposeTxResponse.parseFrom(responseData);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestFogBlockService.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestFogBlockService.java
@@ -21,7 +21,7 @@ public class RestFogBlockService extends RestService implements FogBlockService 
     public Ledger.BlockResponse getBlocks(Ledger.BlockRequest request) {
         try {
             byte[] responseData = getRestClient().makeRequest(
-                    SERVICE_NAME + "/" + "GetBlocks",
+                    PREFIX + SERVICE_NAME + "/" + "GetBlocks",
                     request.toByteArray()
             );
             return Ledger.BlockResponse.parseFrom(responseData);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestFogKeyImageService.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestFogKeyImageService.java
@@ -21,7 +21,7 @@ public class RestFogKeyImageService extends RestService implements FogKeyImageSe
     public Attest.AuthMessage auth(Attest.AuthMessage authMessage) {
         try {
             byte[] responseData = getRestClient().makeRequest(
-                    SERVICE_NAME + "/" + "Auth",
+                    PREFIX + SERVICE_NAME + "/" + "Auth",
                     authMessage.toByteArray()
             );
             return Attest.AuthMessage.parseFrom(responseData);
@@ -34,7 +34,7 @@ public class RestFogKeyImageService extends RestService implements FogKeyImageSe
     public Attest.Message checkKeyImages(Attest.Message request) {
         try {
             byte[] responseData = getRestClient().makeRequest(
-                    SERVICE_NAME + "/" + "CheckKeyImages",
+                    PREFIX + SERVICE_NAME + "/" + "CheckKeyImages",
                     request.toByteArray()
             );
             return Attest.Message.parseFrom(responseData);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestFogMerkleProofService.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestFogMerkleProofService.java
@@ -21,7 +21,7 @@ public class RestFogMerkleProofService extends RestService implements FogMerkleP
     public Attest.Message getOutputs(Attest.Message request) {
         try {
             byte[] responseData = getRestClient().makeRequest(
-                    SERVICE_NAME + "/" + "GetOutputs",
+                    PREFIX + SERVICE_NAME + "/" + "GetOutputs",
                     request.toByteArray()
             );
             return Attest.Message.parseFrom(responseData);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestFogReportService.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestFogReportService.java
@@ -21,7 +21,7 @@ public class RestFogReportService extends RestService implements FogReportServic
     public ReportOuterClass.ReportResponse getReports(ReportOuterClass.ReportRequest request) {
         try {
             byte[] responseData = getRestClient().makeRequest(
-                    SERVICE_NAME + "/" + "GetReports",
+                    PREFIX + SERVICE_NAME + "/" + "GetReports",
                     request.toByteArray()
             );
             return ReportOuterClass.ReportResponse.parseFrom(responseData);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestFogUntrustedService.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestFogUntrustedService.java
@@ -21,7 +21,7 @@ public class RestFogUntrustedService extends RestService implements FogUntrusted
     public Ledger.TxOutResponse getTxOuts(Ledger.TxOutRequest request) {
         try {
             byte[] responseData = getRestClient().makeRequest(
-                    SERVICE_NAME + "/" + "GetTxOuts",
+                    PREFIX + SERVICE_NAME + "/" + "GetTxOuts",
                     request.toByteArray()
             );
             return Ledger.TxOutResponse.parseFrom(responseData);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestFogViewService.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestFogViewService.java
@@ -20,7 +20,7 @@ public class RestFogViewService extends RestService implements FogViewService {
     public Attest.AuthMessage auth(Attest.AuthMessage authMessage) {
         try {
             byte[] responseData = getRestClient().makeRequest(
-                    SERVICE_NAME + "/" + "Auth",
+                    PREFIX + SERVICE_NAME + "/" + "Auth",
                     authMessage.toByteArray()
             );
             return Attest.AuthMessage.parseFrom(responseData);
@@ -32,7 +32,7 @@ public class RestFogViewService extends RestService implements FogViewService {
     public Attest.Message query(Attest.Message queryMessage) {
         try {
             byte[] responseData = getRestClient().makeRequest(
-                    SERVICE_NAME + "/" + "Query",
+                    PREFIX + SERVICE_NAME + "/" + "Query",
                     queryMessage.toByteArray()
             );
             return Attest.Message.parseFrom(responseData);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestService.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/RestService.java
@@ -6,6 +6,7 @@ import com.mobilecoin.lib.network.services.ApiService;
 import com.mobilecoin.lib.network.services.http.clients.RestClient;
 
 abstract class RestService implements ApiService {
+    protected static final String PREFIX = "/gw/";
     private final RestClient restClient;
 
     protected RestService(@NonNull RestClient restClient) {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/clients/RestClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/clients/RestClient.java
@@ -16,7 +16,7 @@ import io.grpc.StatusRuntimeException;
 
 public final class RestClient {
     public final static String METHOD = "POST";
-    public final static String SCHEME = "http";
+    public final static String SCHEME = "https";
     public final static String SET_COOKIE_KEY = "Set-Cookie";
     public final static String COOKIE_KEY = "Cookie";
     public final static String CONTENT_TYPE = "application/x-protobuf";

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.13'
+        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.16'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/testApp/build.gradle
+++ b/testApp/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(":android-sdk")
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.android.support:multidex:1.0.3'
     testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'


### PR DESCRIPTION
### Motivation

We added a URL path prefix `gw` in order to have both HTTP and GRPC services run on the same URL. This PR reflect the change for the clients.

### In this PR
* Add `gw` prefix 
* Switch from GRPC to HTTP
