### PR TITLE
Increase circleci no_output timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,9 @@ jobs:
 
       - run: make setup
       - run: make build
-      - run: make tests
+      - run: 
+        command: make tests
+        no_output_timeout: 20m
 
       - store_artifacts:
           path: android-sdk/build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,9 @@ jobs:
       - run: make setup
       - run: make build
       - run: 
-        command: make tests
-        no_output_timeout: 20m
+          name: make tests
+          command: make tests
+          no_output_timeout: 20m
 
       - store_artifacts:
           path: android-sdk/build/reports


### PR DESCRIPTION
### Motivation


Integration tests take a while to complete and as we added more tests, CircleCI started to fail with a timeout waiting for the tests.

### In this PR
* Increase the circleci timeout to allow the tests to complete

