### PR TITLE
Implement internal load balancer

### DIFF
--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/BlockchainClientTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/BlockchainClientTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 import com.mobilecoin.lib.network.services.BlockchainService;
 import com.mobilecoin.lib.network.services.ServiceAPIManager;
 import com.mobilecoin.lib.network.uri.ConsensusUri;
-
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -18,8 +17,10 @@ import consensus_common.ConsensusCommon;
 public class BlockchainClientTest {
     @Test
     public void clientCachesLastBlockInfo() throws Exception {
+        ConsensusUri consensusUri = new ConsensusUri(
+            Environment.getTestFogConfig().getConsensusUri());
         BlockchainClient blockchainClient = new BlockchainClient(
-                new ConsensusUri(Environment.getTestFogConfig().getConsensusUri()),
+                RandomLoadBalancer.create(consensusUri),
                 Environment.getTestFogConfig().getClientConfig().consensus,
                 Duration.ofHours(1));
         blockchainClient.setAuthorization(
@@ -70,8 +71,10 @@ public class BlockchainClientTest {
 
     @Test
     public void clientRespectsCacheTTL() throws Exception {
+        ConsensusUri consensusUri = new ConsensusUri(
+            Environment.getTestFogConfig().getConsensusUri());
         BlockchainClient blockchainClient = new BlockchainClient(
-                new ConsensusUri(Environment.getTestFogConfig().getConsensusUri()),
+                RandomLoadBalancer.create(consensusUri),
                 Environment.getTestFogConfig().getClientConfig().consensus,
                 Duration.ofMillis(1));
         blockchainClient.setAuthorization(

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/BlockchainClientTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/BlockchainClientTest.java
@@ -7,6 +7,9 @@ import static org.mockito.Mockito.when;
 import com.mobilecoin.lib.network.services.BlockchainService;
 import com.mobilecoin.lib.network.services.ServiceAPIManager;
 import com.mobilecoin.lib.network.uri.ConsensusUri;
+import com.mobilecoin.lib.network.uri.MobileCoinUri;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -54,7 +57,7 @@ public class BlockchainClientTest {
 
         // Setup blockchain client
         BlockchainClient blockchainClient = new BlockchainClient(
-                new ConsensusUri(Environment.getTestFogConfig().getConsensusUri()),
+                createLoadBalancer(),
                 Environment.getTestFogConfig().getClientConfig().consensus,
                 Duration.ofHours(1),
                 apiManager);
@@ -109,7 +112,7 @@ public class BlockchainClientTest {
 
         // Setup blockchain client
         BlockchainClient blockchainClient = new BlockchainClient(
-                new ConsensusUri(Environment.getTestFogConfig().getConsensusUri()),
+                createLoadBalancer(),
                 Environment.getTestFogConfig().getClientConfig().consensus,
                 Duration.ofMillis(1), apiManager);
 
@@ -122,6 +125,15 @@ public class BlockchainClientTest {
         ConsensusCommon.LastBlockInfoResponse lastBlockInfoResponse2 =
                 blockchainClient.getOrFetchLastBlockInfo();
         Assert.assertNotSame(lastBlockInfoResponse1, lastBlockInfoResponse2);
+    }
+
+    private static LoadBalancer createLoadBalancer() throws Exception {
+        ConsensusUri consensusUri =
+            new ConsensusUri(Environment.getTestFogConfig().getConsensusUri());
+        List<MobileCoinUri> consensusUris = new ArrayList<>();
+        consensusUris.add(consensusUri);
+
+        return RandomLoadBalancer.create(consensusUris);
     }
 
 }

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
@@ -38,7 +38,7 @@ public class Environment {
         MobileCoinClient mobileCoinClient = new MobileCoinClient(
                 accountKey,
                 fogConfig.getFogUri(),
-                fogConfig.getConsensusUri(),
+                fogConfig.getConsensusUris(),
                 fogConfig.getClientConfig()
         );
         mobileCoinClient.setFogBasicAuthorization(

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/LedgerTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/LedgerTest.java
@@ -40,8 +40,9 @@ public class LedgerTest {
     @Test
     public void fetch_block_records_test() throws NetworkException, AttestationException,
             InvalidUriException {
+        FogUri fogUri = new FogUri(fogConfig.getFogUri());
         FogBlockClient blockClient = new FogBlockClient(
-                new FogUri(fogConfig.getFogUri()),
+                RandomLoadBalancer.create(fogUri),
                 fogConfig.getClientConfig().fogLedger
         );
 
@@ -106,9 +107,9 @@ public class LedgerTest {
             txoBlock = receiptStatus.getBlockIndex();
             Thread.sleep(1000);
         } while (receiptStatus == Receipt.Status.UNKNOWN);
-
+        FogUri fogUri = new FogUri(fogConfig.getFogUri());
         FogBlockClient blockClient = new FogBlockClient(
-                new FogUri(fogConfig.getFogUri()),
+                RandomLoadBalancer.create(fogUri),
                 fogConfig.getClientConfig().fogLedger
         );
 

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/MobileCoinClientTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/MobileCoinClientTest.java
@@ -600,7 +600,8 @@ public class MobileCoinClientTest {
         Receipt txReceipt = pendingTransaction.getReceipt();
 
         UnsignedLong txBlockIndex = txStatus.getBlockIndex();
-        FogBlockClient blockClient = new FogBlockClient(new FogUri(fogConfig.getFogUri()),
+        FogUri fogUri = new FogUri(fogConfig.getFogUri());
+        FogBlockClient blockClient = new FogBlockClient(RandomLoadBalancer.create(fogUri),
                 ClientConfig.defaultConfig().fogLedger);
         blockClient.setAuthorization(fogConfig.getUsername(), fogConfig.getPassword());
         List<OwnedTxOut> txOuts = blockClient.scanForTxOutsInBlockRange(

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/RandomLoadBalancerTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/RandomLoadBalancerTest.java
@@ -1,0 +1,44 @@
+package com.mobilecoin.lib;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import android.net.Uri;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.mobilecoin.lib.network.uri.ConsensusUri;
+import com.mobilecoin.lib.network.uri.MobileCoinUri;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(AndroidJUnit4.class)
+public class RandomLoadBalancerTest {
+
+  @Test
+  public void getNextServiceUri_singleUri_returnsThatUri() throws Exception {
+    MobileCoinUri serviceUri = new ConsensusUri(Uri.parse("mc://example.com"));
+    RandomLoadBalancer randomLoadBalancer = RandomLoadBalancer.create(serviceUri);
+
+    MobileCoinUri retrievedUri = randomLoadBalancer.getNextServiceUri();
+
+    assertEquals(serviceUri, retrievedUri);
+  }
+
+  @Test
+  public void getNextUrl_multipleUris_calledTwice_returnsNewUri() throws Exception {
+    MobileCoinUri serviceUri1 = new ConsensusUri(Uri.parse("mc://example1.com"));
+    MobileCoinUri serviceUri2 = new ConsensusUri(Uri.parse("mc://example2.com"));
+    MobileCoinUri serviceUri3 = new ConsensusUri(Uri.parse("mc://example3.com"));
+    List<MobileCoinUri> serviceUris = Arrays.asList(serviceUri1, serviceUri2, serviceUri3);
+    RandomLoadBalancer randomLoadBalancer = RandomLoadBalancer.create(serviceUris);
+
+    MobileCoinUri retrievedUri1 = randomLoadBalancer.getNextServiceUri();
+    MobileCoinUri retrievedUri2 = randomLoadBalancer.getNextServiceUri();
+
+    assertNotEquals(retrievedUri1, retrievedUri2);
+  }
+}

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java
@@ -10,6 +10,8 @@ import com.mobilecoin.lib.util.Hex;
 
 import io.grpc.Context.Storage;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -21,7 +23,7 @@ public class TestFogConfig {
     public static final short FOG_REPORT_PRODUCT_ID = 4;
 
     private final Uri fogUri;
-    private final Uri consensusUri;
+    private final List<Uri> consensusUris;
     private final String username;
     private final String password;
     private final ClientConfig clientConfig;
@@ -35,11 +37,11 @@ public class TestFogConfig {
     private static final byte[] alphaFogAuthoritySpki = Base64.decode("MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAyFOockvCEc9TcO1NvsiUfFVzvtDsR64UIRRUl3tBM2Bh8KBA932/Up86RtgJVnbslxuUCrTJZCV4dgd5hAo/mzuJOy9lAGxUTpwWWG0zZJdpt8HJRVLX76CBpWrWEt7JMoEmduvsCR8q7WkSNgT0iIoSXgT/hfWnJ8KGZkN4WBzzTH7hPrAcxPrzMI7TwHqUFfmOX7/gc+bDV5ZyRORrpuu+OR2BVObkocgFJLGmcz7KRuN7/dYtdYFpiKearGvbYqBrEjeo/15chI0Bu/9oQkjPBtkvMBYjyJPrD7oPP67i0ZfqV6xCj4nWwAD3bVjVqsw9cCBHgaykW8ArFFa0VCMdLy7UymYU5SQsfXrw/mHpr27Pp2Z0/7wpuFgJHL+0ARU48OiUzkXSHX+sBLov9X6f9tsh4q/ZRorXhcJi7FnUoagBxewvlfwQfcnLX3hp1wqoRFC4w1DC+ki93vIHUqHkNnayRsf1n48fSu5DwaFfNvejap7HCDIOpCCJmRVR8mVuxi6jgjOUa4Vhb/GCzxfNIn5ZYym1RuoE0TsFO+TPMzjed3tQvG7KemGFz3pQIryb43SbG7Q+EOzIigxYDytzcxOO5Jx7r9i+amQEiIcjBICwyFoEUlVJTgSpqBZGNpznoQ4I2m+uJzM+wMFsinTZN3mp4FU5UHjQsHKG+ZMCAwEAAQ==", Base64.DEFAULT);
     private static final byte[] testNetFogAuthoritySpki = Base64.decode("MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvnB9wTbTOT5uoizRYaYbw7XIEkInl8E7MGOAQj+xnC+F1rIXiCnc/t1+5IIWjbRGhWzo7RAwI5sRajn2sT4rRn9NXbOzZMvIqE4hmhmEzy1YQNDnfALAWNQ+WBbYGW+Vqm3IlQvAFFjVN1YYIdYhbLjAPdkgeVsWfcLDforHn6rR3QBZYZIlSBQSKRMY/tywTxeTCvK2zWcS0kbbFPtBcVth7VFFVPAZXhPi9yy1AvnldO6n7KLiupVmojlEMtv4FQkk604nal+j/dOplTATV8a9AJBbPRBZ/yQg57EG2Y2MRiHOQifJx0S5VbNyMm9bkS8TD7Goi59aCW6OT1gyeotWwLg60JRZTfyJ7lYWBSOzh0OnaCytRpSWtNZ6barPUeOnftbnJtE8rFhF7M4F66et0LI/cuvXYecwVwykovEVBKRF4HOK9GgSm17mQMtzrD7c558TbaucOWabYR04uhdAc3s10MkuONWG0wIQhgIChYVAGnFLvSpp2/aQEq3xrRSETxsixUIjsZyWWROkuA0IFnc8d7AmcnUBvRW7FT/5thWyk5agdYUGZ+7C1o69ihR1YxmoGh69fLMPIEOhYh572+3ckgl2SaV4uo9Gvkz8MMGRBcMIMlRirSwhCfozV2RyT5Wn1NgPpyc8zJL7QdOhL7Qxb+5WjnCVrQYHI2cCAwEAAQ==", Base64.DEFAULT);
 
-    private TestFogConfig(@NonNull Uri fogUri, @NonNull Uri consensusUri, @NonNull String username,
+    private TestFogConfig(@NonNull Uri fogUri, @NonNull List<Uri> consensusUris, @NonNull String username,
                           @NonNull String password, @NonNull ClientConfig clientConfig,
                           @NonNull byte[] fogAuthoritySpki, @NonNull String fogReportId) {
         this.fogUri = fogUri;
-        this.consensusUri = consensusUri;
+        this.consensusUris = consensusUris;
         this.username = username;
         this.password = password;
         this.clientConfig = clientConfig;
@@ -54,7 +56,12 @@ public class TestFogConfig {
 
     @NonNull
     public Uri getConsensusUri() {
-        return consensusUri;
+        return consensusUris.get(0);
+    }
+
+    @NonNull
+    public List<Uri> getConsensusUris() {
+        return consensusUris;
     }
 
     @NonNull
@@ -98,25 +105,33 @@ public class TestFogConfig {
                 "fog://fog.%s.mobilecoin.com",
                 testEnvironment.getName()
         ));
-        final Uri consensusUri = Uri.parse(String.format(
+        final Uri consensusUri1 = Uri.parse(String.format(
                 "mc://node1.%s.mobilecoin.com",
                 testEnvironment.getName()
         ));
+        final Uri consensusUri2 = Uri.parse(String.format(
+            "mc://node2.%s.mobilecoin.com",
+            testEnvironment.getName()
+        ));
+        final Uri consensusUri3 = Uri.parse(String.format(
+            "mc://node3.%s.mobilecoin.com",
+            testEnvironment.getName()
+        ));
 
+        List<Uri> consensusUris = Arrays.asList(consensusUri1, consensusUri2, consensusUri3);
         switch (testEnvironment) {
             case MOBILE_DEV:
-                return new TestFogConfig(fogUri, consensusUri, TEST_USERNAME,
+                return new TestFogConfig(fogUri, consensusUris, TEST_USERNAME,
                         TEST_PASSWORD, getDevClientConfig(storageAdapter),
                         mobiledevFogAuthoritySpki, "");
             case ALPHA:
-                return new TestFogConfig(fogUri, consensusUri, TEST_USERNAME,
+                return new TestFogConfig(fogUri, consensusUris, TEST_USERNAME,
                         TEST_PASSWORD, getDevClientConfig(storageAdapter),
                         alphaFogAuthoritySpki, "");
             case TEST_NET:
-                return new TestFogConfig(fogUri, consensusUri, TEST_USERNAME,
+                return new TestFogConfig(fogUri, consensusUris, TEST_USERNAME,
                         TEST_PASSWORD, getTestNetClientConfig(storageAdapter),
                         testNetFogAuthoritySpki, "");
-
         }
         throw new UnsupportedOperationException("Requested config does not exist");
     }

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TxOutStoreTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TxOutStoreTest.java
@@ -114,8 +114,9 @@ public class TxOutStoreTest {
             Thread.sleep(1000);
         } while (receiptStatus == Receipt.Status.UNKNOWN);
 
+        FogUri fogUri = new FogUri(fogConfig.getFogUri());
         FogBlockClient blockClient = new FogBlockClient(
-                new FogUri(fogConfig.getFogUri()),
+                RandomLoadBalancer.create(fogUri),
                 fogConfig.getClientConfig().fogLedger
         );
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AnyClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AnyClient.java
@@ -64,10 +64,10 @@ class AnyClient extends Native {
         this.transportProtocol = TransportProtocol.forGRPC();
     }
 
-    protected AnyClient(@NonNull MobileCoinUri uri,
+    protected AnyClient(@NonNull LoadBalancer loadBalancer,
                         @NonNull ClientConfig.Service serviceConfig,
                         @NonNull ServiceAPIManager apiManager) {
-        this.serviceUri = uri;
+        this.loadBalancer = loadBalancer;
         this.serviceConfig = serviceConfig;
         this.grpcApiManager = apiManager;
         this.restApiManager = apiManager;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AnyClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AnyClient.java
@@ -257,5 +257,7 @@ class AnyClient extends Native {
             } catch (InterruptedException ignored) { /* */ }
             managedChannel = null;
         }
+
+        restClient = null;
     }
 }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedClient.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 
 import com.google.protobuf.AbstractMessageLite;
 import com.google.protobuf.ByteString;
+import com.mobilecoin.lib.ClientConfig.Service;
 import com.mobilecoin.lib.exceptions.AttestationException;
 import com.mobilecoin.lib.exceptions.NetworkException;
 import com.mobilecoin.lib.log.Logger;
@@ -30,13 +31,12 @@ abstract class AttestedClient extends AnyClient {
 
     /**
      * Creates and initializes an instance of {@link AttestedClient}
-     *
-     * @param uri           a complete {@link Uri} of the service including port.
+     *  @param loadBalancer           a complete {@link Uri} of the service including port.
      * @param serviceConfig service configuration passed to MobileCoinClient
      */
-    protected AttestedClient(@NonNull MobileCoinUri uri,
-                             @NonNull ClientConfig.Service serviceConfig) {
-        super(uri, serviceConfig);
+    protected AttestedClient(@NonNull LoadBalancer loadBalancer,
+                             @NonNull Service serviceConfig) {
+        super(loadBalancer, serviceConfig);
     }
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedConsensusClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedConsensusClient.java
@@ -6,13 +6,14 @@ import androidx.annotation.NonNull;
 
 import com.google.protobuf.ByteString;
 import com.mobilecoin.api.MobileCoinAPI;
+import com.mobilecoin.lib.ClientConfig.Service;
 import com.mobilecoin.lib.exceptions.AttestationException;
 import com.mobilecoin.lib.exceptions.NetworkException;
 import com.mobilecoin.lib.log.Logger;
 import com.mobilecoin.lib.network.services.AttestedService;
 import com.mobilecoin.lib.network.services.ConsensusClientService;
 import com.mobilecoin.lib.network.services.transport.Transport;
-import com.mobilecoin.lib.network.uri.ConsensusUri;
+import com.mobilecoin.lib.network.uri.MobileCoinUri;
 import com.mobilecoin.lib.util.NetworkingCall;
 
 import attest.Attest;
@@ -28,16 +29,15 @@ final class AttestedConsensusClient extends AttestedClient {
 
     /**
      * Creates and initializes an instance of {@link AttestedViewClient}
-     *
-     * @param uri           an address of the service. Example:
+     *  @param loadBalancer           an address of the service. Example:
      *                      mc://consensus.test.mobilecoin.com
      * @param serviceConfig service configuration passed to MobileCoinClient
      */
-    AttestedConsensusClient(@NonNull ConsensusUri uri,
-                            @NonNull ClientConfig.Service serviceConfig) {
-        super(uri, serviceConfig);
+    AttestedConsensusClient(@NonNull LoadBalancer loadBalancer,
+                            @NonNull Service serviceConfig) {
+        super(loadBalancer, serviceConfig);
         Logger.i(TAG, "Created new AttestedConsensusClient", null,
-                "uri:", uri,
+                "loadBalancer:", loadBalancer,
                 "verifier:", serviceConfig);
     }
 
@@ -62,7 +62,7 @@ final class AttestedConsensusClient extends AttestedClient {
             throws AttestationException, NetworkException {
         try {
             Logger.i(TAG, "Attest consensus connection");
-            byte[] requestBytes = attestStart(getServiceUri());
+            byte[] requestBytes = attestStart(getCurrentServiceUri());
             AttestedService attestedService = getAPIManager().getAttestedService(transport);
             ByteString bytes = ByteString.copyFrom(requestBytes);
             Attest.AuthMessage authMessage = Attest.AuthMessage.newBuilder().setData(bytes).build();

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.mobilecoin.api.MobileCoinAPI;
+import com.mobilecoin.lib.ClientConfig.Service;
 import com.mobilecoin.lib.exceptions.AttestationException;
 import com.mobilecoin.lib.exceptions.InvalidFogResponse;
 import com.mobilecoin.lib.exceptions.NetworkException;
@@ -15,7 +16,6 @@ import com.mobilecoin.lib.log.Logger;
 import com.mobilecoin.lib.network.services.FogKeyImageService;
 import com.mobilecoin.lib.network.services.FogMerkleProofService;
 import com.mobilecoin.lib.network.services.transport.Transport;
-import com.mobilecoin.lib.network.uri.FogUri;
 import com.mobilecoin.lib.util.NetworkingCall;
 
 import java.util.ArrayList;
@@ -38,15 +38,14 @@ final class AttestedLedgerClient extends AttestedClient {
 
     /**
      * Creates and initializes an instance of {@link AttestedLedgerClient}
-     *
-     * @param uri           an address of the service. Example:
+     *  @param loadBalancer           an address of the service. Example:
      *                      fog://fog.test.mobilecoin.com
      * @param serviceConfig service configuration passed to MobileCoinClient
      */
-    AttestedLedgerClient(@NonNull FogUri uri, @NonNull ClientConfig.Service serviceConfig) {
-        super(uri, serviceConfig);
+    AttestedLedgerClient(@NonNull LoadBalancer loadBalancer, @NonNull Service serviceConfig) {
+        super(loadBalancer, serviceConfig);
         Logger.i(TAG, "Created new AttestedLedgerClient", null,
-                "uri:", uri,
+                "loadBalancer:", loadBalancer,
                 "verifier:", serviceConfig);
     }
 
@@ -71,7 +70,7 @@ final class AttestedLedgerClient extends AttestedClient {
             throws AttestationException, NetworkException {
         try {
             Logger.i(TAG, "Attest ledger connection");
-            byte[] requestBytes = attestStart(getServiceUri());
+            byte[] requestBytes = attestStart(getCurrentServiceUri());
             FogKeyImageService fogKeyImageService =
                     getAPIManager().getFogKeyImageService(transport);
             ByteString bytes = ByteString.copyFrom(requestBytes);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedViewClient.java
@@ -7,13 +7,13 @@ import androidx.annotation.Nullable;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.mobilecoin.lib.ClientConfig.Service;
 import com.mobilecoin.lib.exceptions.AttestationException;
 import com.mobilecoin.lib.exceptions.InvalidFogResponse;
 import com.mobilecoin.lib.exceptions.NetworkException;
 import com.mobilecoin.lib.log.Logger;
 import com.mobilecoin.lib.network.services.FogViewService;
 import com.mobilecoin.lib.network.services.transport.Transport;
-import com.mobilecoin.lib.network.uri.FogUri;
 import com.mobilecoin.lib.util.NetworkingCall;
 
 import java.util.List;
@@ -32,14 +32,13 @@ final class AttestedViewClient extends AttestedClient {
 
     /**
      * Creates and initializes an instance of {@link AttestedViewClient}
-     *
-     * @param uri           an address of the service
+     *  @param loadBalancer           an address of the service
      * @param serviceConfig service configuration passed to MobileCoinClient
      */
-    AttestedViewClient(@NonNull FogUri uri, @NonNull ClientConfig.Service serviceConfig) {
-        super(uri, serviceConfig);
+    AttestedViewClient(@NonNull LoadBalancer loadBalancer, @NonNull Service serviceConfig) {
+        super(loadBalancer, serviceConfig);
         Logger.i(TAG, "Created new AttestedViewClient", null,
-                "uri:", uri,
+                "loadBalancer:", loadBalancer,
                 "verifier:", serviceConfig);
     }
 
@@ -64,7 +63,7 @@ final class AttestedViewClient extends AttestedClient {
             throws AttestationException, NetworkException {
         try {
             Logger.i(TAG, "Attest view connection");
-            byte[] requestBytes = attestStart(getServiceUri());
+            byte[] requestBytes = attestStart(getCurrentServiceUri());
             FogViewService fogViewService = getAPIManager().getFogViewService(getNetworkTransport());
             ByteString bytes = ByteString.copyFrom(requestBytes);
             Attest.AuthMessage authMessage = Attest.AuthMessage.newBuilder().setData(bytes).build();

--- a/android-sdk/src/main/java/com/mobilecoin/lib/BlockchainClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/BlockchainClient.java
@@ -3,6 +3,7 @@ package com.mobilecoin.lib;
 import androidx.annotation.NonNull;
 
 import com.google.protobuf.Empty;
+import com.mobilecoin.lib.ClientConfig.Service;
 import com.mobilecoin.lib.exceptions.AttestationException;
 import com.mobilecoin.lib.exceptions.NetworkException;
 import com.mobilecoin.lib.log.Logger;
@@ -28,15 +29,14 @@ final class BlockchainClient extends AnyClient {
 
     /**
      * Creates and initializes an instance of {@link BlockchainClient}
-     *
-     * @param uri                a uri of the service
+     *  @param loadBalancer                a uri of the service
      * @param serviceConfig      service configuration passed to MobileCoinClient
      * @param minimumFeeCacheTTL duration of the minimum fee cache lifetime
      */
-    BlockchainClient(@NonNull ConsensusUri uri,
-                     @NonNull ClientConfig.Service serviceConfig,
+    BlockchainClient(@NonNull LoadBalancer loadBalancer,
+                     @NonNull Service serviceConfig,
                      @NonNull Duration minimumFeeCacheTTL) {
-        super(uri, serviceConfig);
+        super(loadBalancer, serviceConfig);
         this.minimumFeeCacheTTL = minimumFeeCacheTTL;
     }
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/BlockchainClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/BlockchainClient.java
@@ -10,7 +10,6 @@ import com.mobilecoin.lib.log.Logger;
 import com.mobilecoin.lib.network.services.BlockchainService;
 import com.mobilecoin.lib.network.services.ServiceAPIManager;
 import com.mobilecoin.lib.network.uri.ConsensusUri;
-import com.mobilecoin.lib.network.uri.FogUri;
 import com.mobilecoin.lib.util.NetworkingCall;
 
 import java.math.BigInteger;
@@ -40,14 +39,14 @@ final class BlockchainClient extends AnyClient {
         this.minimumFeeCacheTTL = minimumFeeCacheTTL;
     }
 
-    BlockchainClient(@NonNull ConsensusUri uri,
+    BlockchainClient(@NonNull LoadBalancer loadBalancer,
                    @NonNull ClientConfig.Service serviceConfig,
                    @NonNull Duration minimumFeeCacheTTL,
                    @NonNull ServiceAPIManager apiManager) {
-        super(uri, serviceConfig, apiManager);
+        super(loadBalancer, serviceConfig, apiManager);
         this.minimumFeeCacheTTL = minimumFeeCacheTTL;
         Logger.i(TAG, "Created new BlockchainClient", null,
-                "uri:", uri,
+                "loadBalancer:", loadBalancer,
                 "verifier:", serviceConfig,
                 "apiManager:", apiManager);
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogBlockClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogBlockClient.java
@@ -6,6 +6,7 @@ package com.mobilecoin.lib;
 import androidx.annotation.NonNull;
 
 import com.mobilecoin.api.MobileCoinAPI;
+import com.mobilecoin.lib.ClientConfig.Service;
 import com.mobilecoin.lib.exceptions.AttestationException;
 import com.mobilecoin.lib.exceptions.NetworkException;
 import com.mobilecoin.lib.log.Logger;
@@ -31,15 +32,14 @@ final class FogBlockClient extends AnyClient {
 
     /**
      * Creates and initializes an instance of {@link FogBlockClient}
-     *
-     * @param uri           an address of the service. Example:
+     *  @param loadBalancer           an address of the service. Example:
      *                      fog://fog.test.mobilecoin.com
      * @param serviceConfig service configuration passed to MobileCoinClient
      */
-    FogBlockClient(@NonNull FogUri uri, @NonNull ClientConfig.Service serviceConfig) {
-        super(uri, serviceConfig);
+    FogBlockClient(@NonNull LoadBalancer loadBalancer, @NonNull Service serviceConfig) {
+        super(loadBalancer, serviceConfig);
         Logger.i(TAG, "Created new FogBlockClient", null,
-                "uri:", uri,
+                "loadBalancer:", loadBalancer,
                 "verifier:", serviceConfig);
     }
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogBlockClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogBlockClient.java
@@ -43,12 +43,12 @@ final class FogBlockClient extends AnyClient {
                 "verifier:", serviceConfig);
     }
 
-    FogBlockClient(@NonNull FogUri uri,
+    FogBlockClient(@NonNull LoadBalancer loadBalancer,
                    @NonNull ClientConfig.Service serviceConfig,
                    @NonNull ServiceAPIManager apiManager) {
-        super(uri, serviceConfig, apiManager);
+        super(loadBalancer, serviceConfig, apiManager);
         Logger.i(TAG, "Created new FogBlockClient", null,
-                "uri:", uri,
+                "loadBalancer:", loadBalancer,
                 "verifier:", serviceConfig,
                 "apiManager:", apiManager);
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogReportsManager.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogReportsManager.java
@@ -4,7 +4,6 @@ package com.mobilecoin.lib;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.mobilecoin.lib.exceptions.FogReportException;
 import com.mobilecoin.lib.exceptions.MobileCoinException;
 import com.mobilecoin.lib.exceptions.NetworkException;
@@ -12,7 +11,6 @@ import com.mobilecoin.lib.log.Logger;
 import com.mobilecoin.lib.network.uri.FogUri;
 import com.mobilecoin.lib.util.Result;
 import com.mobilecoin.lib.util.Task;
-
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.Set;
@@ -89,8 +87,9 @@ final class FogReportsManager {
                 Task<ReportResponse, Exception> task = new Task<ReportResponse, Exception>() {
                     @Override
                     public ReportResponse execute() throws Exception {
-                        ReportClient reportClient = new ReportClient(fogUri,
-                                serviceConfig);
+                        ReportClient reportClient = new ReportClient(
+                            RandomLoadBalancer.create(fogUri),
+                            serviceConfig);
                         ReportResponse response = reportClient.getReports();
                         reportClient.shutdown();
                         return response;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogUntrustedClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogUntrustedClient.java
@@ -5,13 +5,13 @@ package com.mobilecoin.lib;
 
 import androidx.annotation.NonNull;
 
+import com.mobilecoin.lib.ClientConfig.Service;
 import com.mobilecoin.lib.exceptions.AttestationException;
 import com.mobilecoin.lib.exceptions.NetworkException;
 import com.mobilecoin.lib.log.Logger;
 import com.mobilecoin.lib.network.services.FogUntrustedService;
 import com.mobilecoin.lib.network.services.ServiceAPIManager;
 import com.mobilecoin.lib.network.services.transport.Transport;
-import com.mobilecoin.lib.network.uri.FogUri;
 import com.mobilecoin.lib.util.NetworkingCall;
 
 import java.util.Set;
@@ -28,15 +28,14 @@ final class FogUntrustedClient extends AnyClient {
 
     /**
      * Creates and initializes an instance of {@link FogUntrustedClient}
-     *
-     * @param uri           an address of the service. Example:
+     *  @param loadBalancer           an address of the service. Example:
      *                      fog://fog.test.mobilecoin.com
      * @param serviceConfig service configuration passed to MobileCoinClient
      */
-    FogUntrustedClient(@NonNull FogUri uri, @NonNull ClientConfig.Service serviceConfig) {
-        super(uri, serviceConfig);
+    FogUntrustedClient(@NonNull LoadBalancer loadBalancer, @NonNull Service serviceConfig) {
+        super(loadBalancer, serviceConfig);
         Logger.i(TAG, "Created new FogUntrustedClient", null,
-                "uri:", uri,
+                "uri:", loadBalancer,
                 "verifier:", serviceConfig);
     }
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogUntrustedClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogUntrustedClient.java
@@ -12,6 +12,7 @@ import com.mobilecoin.lib.log.Logger;
 import com.mobilecoin.lib.network.services.FogUntrustedService;
 import com.mobilecoin.lib.network.services.ServiceAPIManager;
 import com.mobilecoin.lib.network.services.transport.Transport;
+import com.mobilecoin.lib.network.uri.FogUri;
 import com.mobilecoin.lib.util.NetworkingCall;
 
 import java.util.Set;
@@ -39,12 +40,12 @@ final class FogUntrustedClient extends AnyClient {
                 "verifier:", serviceConfig);
     }
 
-    FogUntrustedClient(@NonNull FogUri uri,
+    FogUntrustedClient(@NonNull LoadBalancer loadBalancer,
                    @NonNull ClientConfig.Service serviceConfig,
                    @NonNull ServiceAPIManager apiManager) {
-        super(uri, serviceConfig, apiManager);
+        super(loadBalancer, serviceConfig, apiManager);
         Logger.i(TAG, "Created new FogUntrustedClient", null,
-                "uri:", uri,
+                "loadBalancer:", loadBalancer,
                 "verifier:", serviceConfig,
                 "apiManager:", apiManager);
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/LoadBalancer.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/LoadBalancer.java
@@ -1,0 +1,11 @@
+package com.mobilecoin.lib;
+
+import com.mobilecoin.lib.network.uri.MobileCoinUri;
+
+/** Balances server load for MobileCoin services. */
+interface LoadBalancer {
+
+  /** Returns a new service {@link MobileCoinUri} upon each invocation. */
+  MobileCoinUri getNextServiceUri();
+
+}

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -114,7 +114,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
      *
      * @param accountKey   user's accountKey
      * @param fogUri       a complete URI for the fog service
-     * @param consensusUris a list of complete URI for the consensus service
+     * @param consensusUris a list of complete URIs for the consensus service
      * @param clientConfig fog and blockchain services networking and attestation configuration
      */
     public MobileCoinClient(

--- a/android-sdk/src/main/java/com/mobilecoin/lib/RandomLoadBalancer.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/RandomLoadBalancer.java
@@ -1,0 +1,57 @@
+package com.mobilecoin.lib;
+
+import android.net.Uri;
+import androidx.annotation.NonNull;
+import com.mobilecoin.lib.network.uri.MobileCoinUri;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+/** Chooses a random service {@link Uri} for each client. */
+final class RandomLoadBalancer implements LoadBalancer {
+
+  private static final Random random = new Random();
+
+  private final List<MobileCoinUri> serviceUris;
+
+  private int lastUsedUriIndex;
+
+  static RandomLoadBalancer create(@NonNull MobileCoinUri serviceUri) {
+    List<MobileCoinUri> mobileCoinUris = Collections
+        .unmodifiableList(Collections.singletonList(serviceUri));
+
+    return new RandomLoadBalancer(mobileCoinUris);
+  }
+
+  static RandomLoadBalancer create(@NonNull List<MobileCoinUri> serviceUris) {
+    if (serviceUris.isEmpty()) {
+      throw new IllegalArgumentException("Service uris is empty.");
+    }
+    return new RandomLoadBalancer(serviceUris);
+  }
+
+  private RandomLoadBalancer(List<MobileCoinUri> serviceUris) {
+    this.serviceUris = serviceUris;
+  }
+
+  @Override
+  public MobileCoinUri getNextServiceUri() {
+    if (serviceUris.size() == 1) {
+      return serviceUris.get(0);
+    }
+
+    return getNextServiceUriForMultipleUris();
+  }
+
+  private MobileCoinUri getNextServiceUriForMultipleUris() {
+    int randomIndex;
+    do {
+      randomIndex = random.nextInt(serviceUris.size());
+    } while (randomIndex == lastUsedUriIndex);
+
+    MobileCoinUri nextServiceUri = serviceUris.get(randomIndex);
+    lastUsedUriIndex = randomIndex;
+
+    return  nextServiceUri;
+  }
+}

--- a/android-sdk/src/main/java/com/mobilecoin/lib/ReportClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/ReportClient.java
@@ -35,12 +35,12 @@ final class ReportClient extends AnyClient {
         super(loadBalancer, serviceConfig);
     }
 
-    ReportClient(@NonNull FogUri uri,
+    ReportClient(@NonNull LoadBalancer loadBalancer,
                    @NonNull ClientConfig.Service serviceConfig,
                    @NonNull ServiceAPIManager apiManager) {
-        super(uri, serviceConfig, apiManager);
+        super(loadBalancer, serviceConfig, apiManager);
         Logger.i(TAG, "Created new ReportClient", null,
-                "uri:", uri,
+                "loadBalancer:", loadBalancer,
                 "verifier:", serviceConfig,
                 "apiManager:", apiManager);
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/ReportClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/ReportClient.java
@@ -5,6 +5,7 @@ package com.mobilecoin.lib;
 import androidx.annotation.NonNull;
 
 import com.google.protobuf.ByteString;
+import com.mobilecoin.lib.ClientConfig.Service;
 import com.mobilecoin.lib.exceptions.AttestationException;
 import com.mobilecoin.lib.exceptions.InvalidFogResponse;
 import com.mobilecoin.lib.exceptions.NetworkException;
@@ -28,10 +29,10 @@ final class ReportClient extends AnyClient {
     /**
      * Creates and initializes an instance of {@link ReportClient}
      *
-     * @param uri address of the service.
+     * @param loadBalancer address of the service.
      */
-    ReportClient(@NonNull FogUri uri, @NonNull ClientConfig.Service serviceConfig) {
-        super(uri, serviceConfig);
+    ReportClient(@NonNull LoadBalancer loadBalancer, @NonNull Service serviceConfig) {
+        super(loadBalancer, serviceConfig);
     }
 
     ReportClient(@NonNull FogUri uri,

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/clients/RestClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/clients/RestClient.java
@@ -119,7 +119,7 @@ public final class RestClient {
     }
 
     @NonNull
-    final Uri getServiceUri() {
+    public final Uri getServiceUri() {
         return serviceUri;
     }
 }


### PR DESCRIPTION
### Motivation
Right now, it's difficult for clients to communicate with multiple consensus nodes. If a consensus node goes down and they'd like to communicate with another node, they have to reinstantiate a `MobileCoinClient` and supply a new `consensusUri`. 

### In this PR
* Creates a `LoadBalancer` interface, which supplies a URI.
* Creates `RandomLoadBalancer`, which implements `LoadBalancer` and supplies a random URI from a list of URIs.
* Creates a new `MobileCoinClient` constructor that allows clients to pass in a list of `consensusUris`. Refactors tests to use this constructor
* Uses `RandomLoadBalancer` to provide a `consensusUri` for client classes that communicate with consensus nodes. This URI is used once per attestation session.
* Nulls out the `restClient` on shutdown. This ensures that a new `consensusUri` is chosen for the next attestation session.

Fixes this [ticket](https://app.asana.com/0/1200318482173758/1200761120709344/f).

### Testing
I created a local test that experiences a `NetworkException` when a transaction is submitted. Attestation resets, and then I submit another transaction. I verified that a new `consensusUri` is used for the second transaction submission. I tested this for both GRPC and HTTP clients.

### Future Work
* Investigate whether or not we should use `LoadBalancer` for Fog URIs.
* Add integration tests that emulate the testing I outlined in the Testing section.  
