### PR TITLE
Fixed MobileCoinClient.setTransportProtocol

### DIFF
--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -754,6 +754,8 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         ledgerClient.setTransportProtocol(protocol);
         consensusClient.setTransportProtocol(protocol);
         blockchainClient.setTransportProtocol(protocol);
+        fogBlockClient.setTransportProtocol(protocol);
+        untrustedClient.setTransportProtocol(protocol);
     }
 
     @Override
@@ -772,6 +774,9 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         }
         if (null != blockchainClient) {
             blockchainClient.shutdown();
+        }
+        if (null != untrustedClient) {
+            untrustedClient.shutdown();
         }
     }
 


### PR DESCRIPTION
### Motivation

This PR fixes an issue with MobileCoinClient where it was not possible to set the transport protocol of the FogUntrustedClient and FogBlockClient.

### In this PR

* Added ability to set the transport protocol of the FogUntrustedClient and FogBlockClient in MobileCoinClient
* Fixed FogUntrustedClient not getting shutdown properly

### Future Work

* Provide an http only build of android-sdk
