### PR TITLE
AnyClient Refactoring

### DIFF
--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/MobileCoinClientTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/MobileCoinClientTest.java
@@ -677,7 +677,8 @@ public class MobileCoinClientTest {
     public void getBalance_afterSetTransportProtocolWithHTTP_retrievesBalance() throws Exception {
         MobileCoinClient mobileCoinClient = MobileCoinClientBuilder.newBuilder().build();
 
-        TransportProtocol httpTransportProtocol = TransportProtocol.forHTTP(new SimpleRequester());
+        TestFogConfig config = Environment.getTestFogConfig();
+        TransportProtocol httpTransportProtocol = TransportProtocol.forHTTP(new SimpleRequester(config.getUsername(), config.getPassword()));
         mobileCoinClient.setTransportProtocol(httpTransportProtocol);
 
         Balance balance = mobileCoinClient.getBalance();
@@ -689,7 +690,8 @@ public class MobileCoinClientTest {
     public void getOrFetchMinimumTxFee_afterSetTransportProtocolWithHTTP_retrievesTransferableAmount() throws Exception {
         MobileCoinClient mobileCoinClient = MobileCoinClientBuilder.newBuilder().build();
 
-        TransportProtocol httpTransportProtocol = TransportProtocol.forHTTP(new SimpleRequester());
+        TestFogConfig config = Environment.getTestFogConfig();
+        TransportProtocol httpTransportProtocol = TransportProtocol.forHTTP(new SimpleRequester(config.getUsername(), config.getPassword()));
         mobileCoinClient.setTransportProtocol(httpTransportProtocol);
 
         BigInteger minimumTxFee = mobileCoinClient.getOrFetchMinimumTxFee();
@@ -702,7 +704,8 @@ public class MobileCoinClientTest {
     @Test
     public void submitTransaction_afterSetTransportProtocolWithHTTP_submitsTransaction() throws Exception {
         MobileCoinClient mobileCoinClient = MobileCoinClientBuilder.newBuilder().build();
-        TransportProtocol httpTransportProtocol = TransportProtocol.forHTTP(new SimpleRequester());
+        TestFogConfig config = Environment.getTestFogConfig();
+        TransportProtocol httpTransportProtocol = TransportProtocol.forHTTP(new SimpleRequester(config.getUsername(), config.getPassword()));
         mobileCoinClient.setTransportProtocol(httpTransportProtocol);
 
         AccountKey recipient = TestKeysManager.getNextAccountKey();

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/SimpleRequester.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/SimpleRequester.java
@@ -28,12 +28,9 @@ public class SimpleRequester implements Requester {
 
     private final OkHttpClient httpClient;
 
-    public SimpleRequester() {
+    public SimpleRequester(String username, String password) {
         httpClient = new OkHttpClient();
-        final String credential = Credentials.basic(
-                Environment.getTestFogConfig().getUsername(),
-                Environment.getTestFogConfig().getPassword()
-        );
+        final String credential = Credentials.basic(username, password);
         httpClient.setAuthenticator(new Authenticator() {
             @Override
             public Request authenticate(Proxy proxy, Response response) throws IOException {

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java
@@ -127,19 +127,20 @@ public class TestFogConfig {
         ));
 
         List<Uri> consensusUris = Arrays.asList(consensusUri1, consensusUri2, consensusUri3);
+        TransportProtocol transportProtocol = TransportProtocol.forGRPC();
         switch (testEnvironment) {
             case MOBILE_DEV:
                 return new TestFogConfig(fogUri, consensusUris, TEST_USERNAME,
                         TEST_PASSWORD, getDevClientConfig(storageAdapter),
-                        mobiledevFogAuthoritySpki, "", TransportProtocol.forGRPC());
+                        mobiledevFogAuthoritySpki, "", transportProtocol);
             case ALPHA:
                 return new TestFogConfig(fogUri, consensusUris, TEST_USERNAME,
                         TEST_PASSWORD, getDevClientConfig(storageAdapter),
-                        alphaFogAuthoritySpki, "", TransportProtocol.forGRPC());
+                        alphaFogAuthoritySpki, "", transportProtocol);
             case TEST_NET:
                 return new TestFogConfig(fogUri, consensusUris, TEST_USERNAME,
                         TEST_PASSWORD, getTestNetClientConfig(storageAdapter),
-                        testNetFogAuthoritySpki, "", TransportProtocol.forGRPC());
+                        testNetFogAuthoritySpki, "", transportProtocol);
         }
         throw new UnsupportedOperationException("Requested config does not exist");
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/transport/GRPCTransport.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/transport/GRPCTransport.java
@@ -2,13 +2,68 @@ package com.mobilecoin.lib.network.services.transport;
 
 import androidx.annotation.NonNull;
 
+import com.mobilecoin.lib.ClientConfig;
+import com.mobilecoin.lib.exceptions.NetworkException;
+import com.mobilecoin.lib.log.Logger;
+import com.mobilecoin.lib.network.NetworkResult;
+import com.mobilecoin.lib.network.uri.MobileCoinUri;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManagerFactory;
+
 import io.grpc.ManagedChannel;
+import io.grpc.okhttp.OkHttpChannelBuilder;
 
 public class GRPCTransport extends Transport {
+    private static final String TAG = GRPCTransport.class.getName();
+    // How long to wait for the managed connection to gracefully shutdown in milliseconds
+    private final static long MANAGED_CONNECTION_SHUTDOWN_TIME_LIMIT = 1000;
+
     private final ManagedChannel managedChannel;
 
-    GRPCTransport(@NonNull ManagedChannel managedChannel) {
-        this.managedChannel = managedChannel;
+    GRPCTransport(@NonNull MobileCoinUri uri, @NonNull ClientConfig.Service serviceConfiguration) throws NetworkException {
+        try {
+            Logger.i(TAG, "Managed channel does not exist: creating one");
+            OkHttpChannelBuilder managedChannelBuilder = OkHttpChannelBuilder
+                    .forAddress(
+                            uri.getUri().getHost(),
+                            uri.getUri().getPort()
+                    );
+            if (uri.isTlsEnabled()) {
+                managedChannelBuilder.useTransportSecurity();
+            } else {
+                managedChannelBuilder.usePlaintext();
+            }
+            Set<X509Certificate> trustRoots = serviceConfiguration.getTrustRoots();
+            if (trustRoots != null && trustRoots.size() > 0) {
+                KeyStore caKeyStore = getTrustRootsKeyStore(trustRoots);
+                SSLSocketFactory sslSocketFactory = getTrustedSSLSocketFactory(caKeyStore);
+                managedChannelBuilder.sslSocketFactory(sslSocketFactory);
+            }
+            this.managedChannel = managedChannelBuilder.build();
+        } catch (Exception ex) {
+            NetworkException exception = new NetworkException(NetworkResult.UNKNOWN
+                    .withDescription("Unable to create managed channel")
+                    .withCause(ex));
+            String message = exception.getMessage();
+            if (null == message) {
+                message = "";
+            }
+            Logger.w(TAG, message, exception);
+            throw(exception);
+        }
     }
 
     @NonNull
@@ -21,4 +76,57 @@ public class GRPCTransport extends Transport {
     public TransportType getTransportType() {
         return TransportType.GRPC;
     }
+
+    /**
+     * Create a new SSLSocketFactory
+     *
+     * @param trustRootsKeyStore keystore containing the trust anchors
+     */
+    @NonNull
+    private static SSLSocketFactory getTrustedSSLSocketFactory(@NonNull KeyStore trustRootsKeyStore)
+            throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+
+        // initialize trust manager from certs keystore
+        TrustManagerFactory tmf =
+                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(trustRootsKeyStore);
+
+        // initialize SSL context from trust manager factory
+        SSLContext context = SSLContext.getInstance("TLS");
+        if (context == null) {
+            throw new NoSuchAlgorithmException("TLS is not supported");
+        }
+        context.init(null, tmf.getTrustManagers(), new SecureRandom());
+
+        // return socket factory from the SSL context
+        return context.getSocketFactory();
+    }
+
+    /**
+     * Load CA anchors into a KeyStore
+     */
+    @NonNull
+    private static KeyStore getTrustRootsKeyStore(@NonNull Set<X509Certificate> trustRoots)
+            throws KeyStoreException, NoSuchAlgorithmException, IOException, CertificateException {
+        KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+        ks.load(null, null);
+        for (X509Certificate trustRoot : trustRoots) {
+            ks.setCertificateEntry(trustRoot.toString(), trustRoot);
+        }
+        return ks;
+    }
+
+    @Override
+    public void shutdown() {
+        try {
+            this.managedChannel.shutdown();
+            Logger.i(TAG, "Shutting down the managed channel, awaiting for termination...");
+            managedChannel.awaitTermination(
+                    MANAGED_CONNECTION_SHUTDOWN_TIME_LIMIT,
+                    TimeUnit.MILLISECONDS
+            );
+            Logger.i(TAG, "The managed channel has been shut down");
+        } catch(InterruptedException ignored) {/*  */}
+    }
+
 }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/transport/RestTransport.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/transport/RestTransport.java
@@ -21,4 +21,8 @@ public class RestTransport extends Transport {
     public TransportType getTransportType() {
         return TransportType.HTTP;
     }
+
+    @Override
+    public void shutdown() {/*  */}
+
 }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/transport/RestTransport.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/transport/RestTransport.java
@@ -2,13 +2,16 @@ package com.mobilecoin.lib.network.services.transport;
 
 import androidx.annotation.NonNull;
 
+import com.mobilecoin.lib.network.TransportProtocol;
 import com.mobilecoin.lib.network.services.http.clients.RestClient;
+import com.mobilecoin.lib.network.uri.MobileCoinUri;
 
 public class RestTransport extends Transport {
     private final RestClient restClient;
 
-    public RestTransport(@NonNull RestClient restClient) {
-        this.restClient = restClient;
+    public RestTransport(@NonNull TransportProtocol transportProtocol,
+                         @NonNull MobileCoinUri currentUri) {
+        this.restClient = new RestClient(currentUri.getUri(), transportProtocol.getHttpRequester());
     }
 
     @NonNull

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/transport/Transport.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/transport/Transport.java
@@ -2,21 +2,32 @@ package com.mobilecoin.lib.network.services.transport;
 
 import androidx.annotation.NonNull;
 
+import com.mobilecoin.lib.ClientConfig;
+import com.mobilecoin.lib.exceptions.NetworkException;
+import com.mobilecoin.lib.network.TransportProtocol;
 import com.mobilecoin.lib.network.services.http.clients.RestClient;
-
-import io.grpc.ManagedChannel;
+import com.mobilecoin.lib.network.uri.MobileCoinUri;
 
 public abstract class Transport {
-    public static RestTransport fromRestClient(@NonNull RestClient restClient) {
-        return new RestTransport(restClient);
-    }
 
-    public static GRPCTransport fromManagedChannel(@NonNull ManagedChannel managedChannel) {
-        return new GRPCTransport(managedChannel);
+    public synchronized static Transport forConfig(@NonNull TransportProtocol transportProtocol,
+                                                   @NonNull MobileCoinUri currentUri,
+                                                   @NonNull ClientConfig.Service serviceConfig)
+                                                throws NetworkException {
+        switch(transportProtocol.getTransportType()) {
+            case GRPC:
+                return new GRPCTransport(currentUri, serviceConfig);
+            case HTTP:
+                return new RestTransport(new RestClient(currentUri.getUri(), transportProtocol.getHttpRequester()));
+            default:
+                throw new UnsupportedOperationException("Unsupported protocol");
+        }
     }
 
     @NonNull
     public abstract TransportType getTransportType();
+
+    public abstract void shutdown();
 
     public enum TransportType {
         GRPC,

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/transport/Transport.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/transport/Transport.java
@@ -5,7 +5,6 @@ import androidx.annotation.NonNull;
 import com.mobilecoin.lib.ClientConfig;
 import com.mobilecoin.lib.exceptions.NetworkException;
 import com.mobilecoin.lib.network.TransportProtocol;
-import com.mobilecoin.lib.network.services.http.clients.RestClient;
 import com.mobilecoin.lib.network.uri.MobileCoinUri;
 
 public abstract class Transport {
@@ -18,7 +17,7 @@ public abstract class Transport {
             case GRPC:
                 return new GRPCTransport(currentUri, serviceConfig);
             case HTTP:
-                return new RestTransport(new RestClient(currentUri.getUri(), transportProtocol.getHttpRequester()));
+                return new RestTransport(transportProtocol, currentUri);
             default:
                 throw new UnsupportedOperationException("Unsupported protocol");
         }


### PR DESCRIPTION
Remove all references to GRPC and HTTP specific functionality from AnyClient and AttestedClient
Fixed a TestFogConfig bug with HTTP TransportProtocol

### Motivation
AnyClient and AttestedClient have an unnecessary dependencies on grpc ManagedChannel and RestClient. This PR reomves those dependencies by initializing the network transport in Transport and moving protocol-specific knowledge from this process into the individual implementations.

### In this PR
* Remove AnyClient and AttestedClient knowledge of TransportProtocol type
* Fix for TestFogConfig SimpleRequester recursive call

### Future Work
* Flavors and source sets for protocols
