### PR TITLE
Add CI configuration to automate publishing tagged releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,14 +57,12 @@ workflows:
       - test
 
   android-sdk-release:
-    triggers:
-      - schedule:
+    jobs:
+      - android-release
           filters:
             branches:
               only:
                 - ci
-    jobs:
-      - android-release
 
   # android-bindings-release:
   #   triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           name: Store Google Service Account
           command: echo $GCLOUD_SERVICE_KEY > service-key.json
-      
+
       - run:
           name: Provide Dev credentials
           command: sed -i 's/REPLACE_TEST_DEV_USER_STRING/'"$TEST_DEV_USER"'/g' android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java && sed -i 's/REPLACE_TEST_DEV_PASSWORD_STRING/'"$TEST_DEV_PASSWORD"'/g' android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java
@@ -23,12 +23,12 @@ jobs:
           command: echo $TEST_NET_MNEMONICS > android-sdk/src/androidTest/res/raw/test_net_mnemonics
 
       - run:
-          name: Provide DevNet entropies 
+          name: Provide DevNet entropies
           command: echo $DEV_NET_TEST_ENTROPIES > android-sdk/src/androidTest/res/raw/dev_net_root_entropies
 
       - run: make setup
       - run: make build
-      - run: 
+      - run:
           name: make tests
           command: make tests
           no_output_timeout: 20m
@@ -59,12 +59,12 @@ workflows:
   android-sdk-release:
     triggers:
       - schedule:
-        filters:
-          branches:
-            only:
-              - ci
-      jobs:
-        - android-release
+          filters:
+            branches:
+              only:
+                - ci
+    jobs:
+      - android-release
 
   # android-bindings-release:
   #   triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,15 +48,13 @@ workflows:
   version: 2
   run-tests:
     jobs:
-      - test:
-          filters:
-            branches:
-              ignore:
-                - ci
+      - test
   android-sdk-release:
     jobs:
       - android-release:
           filters:
             branches:
               only:
-                - ci
+                - master
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,10 @@ jobs:
       - run: make build
       # - run: make deploy
 
-  bindings-release:
-    machine:
-      image: ubuntu-2004:202010-01
-    steps:
+  # bindings-release:
+  #   machine:
+  #     image: ubuntu-2004:202010-01
+  #   steps:
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,21 +41,18 @@ jobs:
     machine:
       image: ubuntu-2004:202010-01
     steps:
-      - run: make build
-      # - run: make deploy
-
-  # bindings-release:
-  #   machine:
-  #     image: ubuntu-2004:202010-01
-  #   steps:
+      - checkout
+      - run: make publish
 
 workflows:
   version: 2
-
   run-tests:
     jobs:
-      - test
-
+      - test:
+          filters:
+            branches:
+              ignore:
+                - ci
   android-sdk-release:
     jobs:
       - android-release:
@@ -63,13 +60,3 @@ workflows:
             branches:
               only:
                 - ci
-
-  # android-bindings-release:
-  #   triggers:
-  #   - schedule:
-  #     filters:
-  #       branches:
-  #         only:
-  #           - ci
-  #   jobs:
-  #     - bindings-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ workflows:
 
   android-sdk-release:
     jobs:
-      - android-release
+      - android-release:
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,41 @@ jobs:
           path: android-sdk/build/reports
           destination: reports
 
+  android-release:
+    machine:
+      image: ubuntu-2004:202010-01
+    steps:
+      - run: make build
+      # - run: make deploy
+
+  bindings-release:
+    machine:
+      image: ubuntu-2004:202010-01
+    steps:
+
 workflows:
   version: 2
 
   run-tests:
     jobs:
       - test
+
+  android-sdk-release:
+    triggers:
+      - schedule:
+        filters:
+          branches:
+            only:
+              - ci
+      jobs:
+        - android-release
+
+  # android-bindings-release:
+  #   triggers:
+  #   - schedule:
+  #     filters:
+  #       branches:
+  #         only:
+  #           - ci
+  #   jobs:
+  #     - bindings-release

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ lint/outputs/
 lint/tmp/
 # lint/reports/
 
+# VSCode Dev Containers & Settings
+.devcontainer/
+.vscode/

--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'maven-publish'
 
 // version '1.2.0-pre0'
-version '0.0.1-pre001'
+version '0.0.1-pre002'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'maven-publish'
 
-version '1.2.0-pre0'
+// version '1.2.0-pre0'
+version '0.0.1-pre001'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()
@@ -36,10 +37,15 @@ publishing {
             url = "https://maven.cloudsmith.io/mobilecoin/mobilecoin/"
             def releasesRepoUrl = "https://maven.cloudsmith.io/mobilecoin/mobilecoin/"
             def snapshotsRepoUrl = "https://maven.cloudsmith.io/mobilecoin/mobilecoin/"
+            def localMavenUser = properties.getProperty("maven.user")
+            def localMavenPassword = properties.getProperty("maven.apikey")
+            // CI - Get Maven Creds from Env Vars if no local.properties
+            def mavenUser =  localMavenUser != null ? localMavenUser : System.getenv('MAVEN_USER')
+            def mavenPassword = localMavenPassword != null ? localMavenPassword : System.getenv('MAVEN_PASSWORD')
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
-                username = properties.getProperty("maven.user")
-                password = properties.getProperty("maven.apikey")
+                username = mavenUser
+                password = mavenPassword
             }
         }
     }

--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'maven-publish'
 
-// version '1.2.0-pre0'
-version '0.0.1-pre002'
+version '1.2.0-pre0'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/makefile
+++ b/makefile
@@ -42,6 +42,8 @@ deployLocal: setup
 
 publish: setup
 # Check if we are in the CircleCI environment
+# If not in CI env then use local.properties values to publish
+# May not need this but it allows publishing from local if needed
 	@if [ -z "${MAVEN_USER}" ]; then \
 		docker run \
 			-it \

--- a/makefile
+++ b/makefile
@@ -47,7 +47,7 @@ publish: setup
 			-it \
 			-v $(pwd):/home/gradle/ \
 			-w /home/gradle/ android-build:android-gradle \
-			-c "gradle clean; gradle assemble; gradle publish"; \
+			'gradle clean && gradle assemble && gradle publish'; \
 	else \
 		echo "Running CI Publish"; \
 		docker run \
@@ -56,7 +56,7 @@ publish: setup
 			-e MAVEN_USER \
 			-e MAVEN_PASSWORD \
 			-w /home/gradle/ android-build:android-gradle \
-			-c "gradle clean; gradle assemble; gradle publish"; \
+			'gradle clean && gradle assemble && gradle publish'; \
 	fi
 
 bash: setup

--- a/makefile
+++ b/makefile
@@ -40,6 +40,29 @@ deployLocal: setup
 		android-build:android-gradle \
 		gradle publishToMavenLocal
 
+publish: setup
+# Check if we are in the CircleCI environment
+	@if [ -z "${MAVEN_USER}" ]; then \
+		docker run \
+			-it \
+			-v $(pwd):/home/gradle/ \
+			-w /home/gradle/ android-build:android-gradle \
+			gradle clean \
+			gradle assemble \
+			gradle publish; \
+	else \
+		echo "Running CI Publish"; \
+		docker run \
+			-it \
+			-v $(pwd):/home/gradle/ \
+			-e MAVEN_USER \
+			-e MAVEN_PASSWORD \
+			-w /home/gradle/ android-build:android-gradle \
+			gradle clean \
+			gradle assemble \
+			gradle publish; \
+	fi
+
 bash: setup
 	docker run \
 		-it \
@@ -47,8 +70,7 @@ bash: setup
 		-v $(maven_repo):/root/.m2/ \
 		-w /home/gradle/ android-build:android-gradle \
 		bash
-
+	
 setup: dockerImage
 
 all: setup clean build deployLocal
-

--- a/makefile
+++ b/makefile
@@ -47,9 +47,7 @@ publish: setup
 			-it \
 			-v $(pwd):/home/gradle/ \
 			-w /home/gradle/ android-build:android-gradle \
-			gradle clean \
-			gradle assemble \
-			gradle publish; \
+			-c "gradle clean; gradle assemble; gradle publish"; \
 	else \
 		echo "Running CI Publish"; \
 		docker run \
@@ -58,9 +56,7 @@ publish: setup
 			-e MAVEN_USER \
 			-e MAVEN_PASSWORD \
 			-w /home/gradle/ android-build:android-gradle \
-			gradle clean \
-			gradle assemble \
-			gradle publish; \
+			-c "gradle clean; gradle assemble; gradle publish"; \
 	fi
 
 bash: setup

--- a/makefile
+++ b/makefile
@@ -47,7 +47,7 @@ publish: setup
 			-it \
 			-v $(pwd):/home/gradle/ \
 			-w /home/gradle/ android-build:android-gradle \
-			'gradle clean && gradle assemble && gradle publish'; \
+			bash -c 'gradle clean && gradle assemble && gradle publish'; \
 	else \
 		echo "Running CI Publish"; \
 		docker run \
@@ -56,7 +56,7 @@ publish: setup
 			-e MAVEN_USER \
 			-e MAVEN_PASSWORD \
 			-w /home/gradle/ android-build:android-gradle \
-			'gradle clean && gradle assemble && gradle publish'; \
+			bash -c 'gradle clean && gradle assemble && gradle publish'; \
 	fi
 
 bash: setup


### PR DESCRIPTION
### Motivation

Publishing the Android-sdk to a Maven repository has been a manual process until now.  This PR adds CircleCI functionality to automate the publishing of the AAR file to cloudsmith for TAGGED releases of the Master branch in the format of `v.x.x.x*`

### In this PR
* Added a new CirclCI workflow and job for publishing the SDK for tagged releases on the master branch
* Added logic in publish.gradle to pull secrets from environment variables when running in CI or from the local.properties file if running locally
* Added new `publish` entry to makefile to handle needed steps for publishing to cloudsmith

### Future Work
* This work did not take into account building the android bindings  We should look at options to publish and version those dependencies which can be referenced here.
* Do we need to include updates to the readme for building the bindings and putting them in this repo?  If we can get the work in the above bullet working it would negate this issue.
* A possible optimization would be for us to create a base build image and just pull that image vs rebuilding it each time we run a step in the make file.  We could schedule this to get rebuilt periodically, i.e - weekly
   * This is not too major of a thing as it doesn't take long to build
