### PR TITLE
Fix ci config to ignore all branches on publish task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ workflows:
       - android-release:
           filters:
             branches:
-              only:
-                - master
+              ignore: /.*/
             tags:
               only: /^v.*/


### PR DESCRIPTION
### Motivation

The original intent of the publish CI steps was to only run when a tag was pushed for the master branch.  I misunderstood the documentation and that is not how it works. CircleCI will do an `OR` on the current configuration and will run anytime code is pushed to the master branch OR a tag is pushed.

### In this PR
* Change the circleci config to ignore all branches for the publish job and only run when a tag is pushed.

