### PR TITLE
Add Action to perform tests against specified network

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,52 @@
+name: sdk-tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'MobileCoin Network'
+        required: true
+        default: 'MOBILE_DEV'
+        type: choice
+        options:
+          - 'MOBILE_DEV'
+          - 'ALPHA'
+          - 'TEST_NET'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: GCP Service Account
+        run: |
+          echo '${{ secrets.GCP_SERVICE_KEY }}' > "service-key.json"
+
+      - name: Provide Dev Credentials
+        env:
+          TEST_DEV_USER: ${{ secrets.TEST_DEV_USER }}
+          TEST_DEV_PASSWORD: ${{ secrets.TEST_DEV_PASSWORD }}
+        run: |
+          sed -i 's/REPLACE_TEST_DEV_USER_STRING/'"${TEST_DEV_USER}"'/g' android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java && \
+          sed -i 's/REPLACE_TEST_DEV_PASSWORD_STRING/'"${TEST_DEV_PASSWORD}"'/g' android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java
+
+      - name: Set the Network
+        env:
+          NETWORK_UNDER_TEST: ${{ github.event.inputs.network }}
+        run: sed -i 's/TestEnvironment.ALPHA/'"TestEnvironment.${NETWORK_UNDER_TEST}"'/g' android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
+
+      - name: Provide DevNet Entropies
+        run: echo "${{ secrets.DEV_NET_ENTROPIES }}" > "android-sdk/src/androidTest/res/raw/dev_net_root_entropies"
+
+      - name: Provide TestNet Mnemonics
+        run: echo "${{ secrets.TEST_NET_MNEMONICS }}" > "android-sdk/src/androidTest/res/raw/test_net_mnemonics"
+
+      - name: Build
+        run: make build
+
+      - name: Test
+        timeout-minutes: 25
+        run: make tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,13 +30,13 @@ jobs:
           TEST_DEV_USER: ${{ secrets.TEST_DEV_USER }}
           TEST_DEV_PASSWORD: ${{ secrets.TEST_DEV_PASSWORD }}
         run: |
-          sed -i 's/REPLACE_TEST_DEV_USER_STRING/'"${TEST_DEV_USER}"'/g' android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java && \
-          sed -i 's/REPLACE_TEST_DEV_PASSWORD_STRING/'"${TEST_DEV_PASSWORD}"'/g' android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java
+          sed -i "s/REPLACE_TEST_DEV_USER_STRING/${TEST_DEV_USER}/g" android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java && \
+          sed -i "s/REPLACE_TEST_DEV_PASSWORD_STRING/${TEST_DEV_PASSWORD}/g" android-sdk/src/androidTest/java/com/mobilecoin/lib/TestFogConfig.java
 
       - name: Set the Network
         env:
           NETWORK_UNDER_TEST: ${{ github.event.inputs.network }}
-        run: sed -i 's/TestEnvironment.ALPHA/'"TestEnvironment.${NETWORK_UNDER_TEST}"'/g' android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
+        run: sed -i "s/TestEnvironment\.[a-zA-Z_]*/TestEnvironment.${NETWORK_UNDER_TEST}/g" android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
 
       - name: Provide DevNet Entropies
         run: echo "${{ secrets.DEV_NET_ENTROPIES }}" > "android-sdk/src/androidTest/res/raw/dev_net_root_entropies"

--- a/docker/scripts/run_connected_tests.sh
+++ b/docker/scripts/run_connected_tests.sh
@@ -11,4 +11,5 @@ gcloud firebase test android run \
     --type instrumentation \
     --device model=Nexus5X,version=24 \
     --app testApp/build/outputs/apk/debug/testApp-debug.apk \
-    --test android-sdk/build/outputs/apk/androidTest/grpc/debug/android-sdk-grpc-debug-androidTest.apk
+    --test android-sdk/build/outputs/apk/androidTest/grpc/debug/android-sdk-grpc-debug-androidTest.apk \
+    --timeout 45m


### PR DESCRIPTION
### Motivation

This is needed to allow individuals the ability to perform tests against the specified network.  Primarily the infrastructure team will use this to validate any configuration changes do not break functionality.  Alleviates disruption to the mobile dev team to run out of band tests for the infrastructure team.This can also be used by anyone else needing to manually kick off a test.

### In this PR
* Added a GitHub action `workflow_dispatch` that allows authorized users to kick off the android-sdk tests by supplying which network to run the tests against.
* Added the necessary Action Secrets to perform the tests.
* Added a `timeout` value to the gcloud test cmdline.  Default is 15m and with the inclusion of additional tests we were hitting this limit on testnet.

### Follow up
* Look at optimizing tests to clean up technical debt. 

