### PR TITLE
Verify Correctness of Reconstructed Commitment

### DIFF
--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/OwnedTxOutTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/OwnedTxOutTest.java
@@ -170,7 +170,7 @@ public class OwnedTxOutTest {
   }
 
   @Test
-  public void testMatchingCrc32ParsesCorrectly() throws Exception {
+  public void testVerifyCorrectCommitment() throws Exception {
     // Test parsing of valid and invalid TxOuts with no commitment data but with commitment crc32
 
     // Test valid with CRC32

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/OwnedTxOutTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/OwnedTxOutTest.java
@@ -1,7 +1,6 @@
 package com.mobilecoin.lib;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import android.os.Parcel;
@@ -19,7 +18,6 @@ import org.junit.runners.JUnit4;
 
 import java.util.Arrays;
 
-import fog_view.View;
 import fog_view.View.TxOutRecord;
 
 @RunWith(JUnit4.class)
@@ -176,8 +174,8 @@ public class OwnedTxOutTest {
     // Test parsing of valid and invalid TxOuts with no commitment data but with commitment crc32
 
     // Test valid with CRC32
-    View.TxOutRecord recordWithCrc32 = TxOutRecord.parseFrom(Hex.toByteArray(viewRecordWithSenderMemoHexProtoBytes));
-    View.TxOutRecord invalidRecordWithCrc32 = TxOutRecord.newBuilder(recordWithCrc32)
+    TxOutRecord recordWithCrc32 = TxOutRecord.parseFrom(Hex.toByteArray(viewRecordWithSenderMemoHexProtoBytes));
+    TxOutRecord invalidRecordWithCrc32 = TxOutRecord.newBuilder(recordWithCrc32)
             .setTxOutAmountCommitmentDataCrc32(
                     recordWithCrc32.getTxOutAmountCommitmentDataCrc32() - 1
             ).build();
@@ -199,7 +197,7 @@ public class OwnedTxOutTest {
             recordWithCrc32.getTxOutAmountMaskedValue(),
             recordWithCrc32.getTxOutAmountMaskedTokenId().toByteArray()
     ).getCommitment();
-    View.TxOutRecord recordWithCommitment = TxOutRecord.newBuilder(recordWithCrc32)
+    TxOutRecord recordWithCommitment = TxOutRecord.newBuilder(recordWithCrc32)
             .setTxOutAmountCommitmentDataCrc32(0)
             .setTxOutAmountCommitmentData(ByteString.copyFrom(validCommitmentData))
             .build();
@@ -208,7 +206,7 @@ public class OwnedTxOutTest {
     // Test invalid with commitment
     byte invalidCommitmentData[] = Arrays.copyOf(validCommitmentData, validCommitmentData.length);
     invalidCommitmentData[0] = (byte)(validCommitmentData[0] - 1);
-    View.TxOutRecord recordWithInvalidCommitment = TxOutRecord.newBuilder(recordWithCrc32)
+    TxOutRecord recordWithInvalidCommitment = TxOutRecord.newBuilder(recordWithCrc32)
             .setTxOutAmountCommitmentDataCrc32(0)
             .setTxOutAmountCommitmentData(ByteString.copyFrom(invalidCommitmentData))
             .build();

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/OwnedTxOutTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/OwnedTxOutTest.java
@@ -1,10 +1,14 @@
 package com.mobilecoin.lib;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import android.os.Parcel;
 import android.util.Log;
 
+import com.google.protobuf.ByteString;
+import com.mobilecoin.lib.exceptions.SerializationException;
 import com.mobilecoin.lib.util.Hex;
 
 import org.junit.Assert;
@@ -13,6 +17,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.Arrays;
+
+import fog_view.View;
 import fog_view.View.TxOutRecord;
 
 @RunWith(JUnit4.class)
@@ -162,6 +169,56 @@ public class OwnedTxOutTest {
       assertEquals(parcelInput, parcelOutput);
       parcel.recycle();
     }
+  }
+
+  @Test
+  public void testMatchingCrc32ParsesCorrectly() throws Exception {
+    // Test parsing of valid and invalid TxOuts with no commitment data but with commitment crc32
+
+    // Test valid with CRC32
+    View.TxOutRecord recordWithCrc32 = TxOutRecord.parseFrom(Hex.toByteArray(viewRecordWithSenderMemoHexProtoBytes));
+    View.TxOutRecord invalidRecordWithCrc32 = TxOutRecord.newBuilder(recordWithCrc32)
+            .setTxOutAmountCommitmentDataCrc32(
+                    recordWithCrc32.getTxOutAmountCommitmentDataCrc32() - 1
+            ).build();
+    OwnedTxOut txOutFromCrc32 = new OwnedTxOut(recordWithCrc32, receiverAccountKey);
+
+    // Test invalid with CRC32
+    try {
+      OwnedTxOut txOutFromInvalidCrc32 = new OwnedTxOut(invalidRecordWithCrc32, receiverAccountKey);
+      fail("Parsing of invalid record must fail");
+    } catch(IllegalArgumentException e) {
+      assertEquals(SerializationException.class, e.getCause().getClass());
+    }
+
+    // Test valid with commitment
+    RistrettoPublic txOutSharedSecret =
+            Util.getSharedSecret(receiverAccountKey.getViewKey(), txOutFromCrc32.getPublicKey());
+    byte validCommitmentData[] = new MaskedAmount(
+            txOutSharedSecret,
+            recordWithCrc32.getTxOutAmountMaskedValue(),
+            recordWithCrc32.getTxOutAmountMaskedTokenId().toByteArray()
+    ).getCommitment();
+    View.TxOutRecord recordWithCommitment = TxOutRecord.newBuilder(recordWithCrc32)
+            .setTxOutAmountCommitmentDataCrc32(0)
+            .setTxOutAmountCommitmentData(ByteString.copyFrom(validCommitmentData))
+            .build();
+    OwnedTxOut txOutFromCommitment = new OwnedTxOut(recordWithCommitment, receiverAccountKey);
+
+    // Test invalid with commitment
+    byte invalidCommitmentData[] = Arrays.copyOf(validCommitmentData, validCommitmentData.length);
+    invalidCommitmentData[0] = (byte)(validCommitmentData[0] - 1);
+    View.TxOutRecord recordWithInvalidCommitment = TxOutRecord.newBuilder(recordWithCrc32)
+            .setTxOutAmountCommitmentDataCrc32(0)
+            .setTxOutAmountCommitmentData(ByteString.copyFrom(invalidCommitmentData))
+            .build();
+    try {
+      OwnedTxOut txOutFromInvalidCommitment = new OwnedTxOut(recordWithInvalidCommitment, receiverAccountKey);
+      fail("Parsing of invalid record must fail");
+    } catch(IllegalArgumentException e) {
+      assertEquals(SerializationException.class, e.getCause().getClass());
+    }
+
   }
 
 }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
@@ -8,6 +8,7 @@ import android.os.Parcelable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.protobuf.ByteString;
 import com.mobilecoin.api.MobileCoinAPI;
 import com.mobilecoin.api.MobileCoinAPI.EncryptedMemo;
 import com.mobilecoin.lib.exceptions.AmountDecoderException;
@@ -85,6 +86,21 @@ public class OwnedTxOut implements Parcelable {
                     accountKey.getViewKey(),
                     txOutPublicKey
             );
+
+            // Verify reconstructed commitment
+            final byte reconstructedCommitment[] = maskedAmount.getCommitment();
+            final int reconstructedCrc32 = Util.computeCommittmentCrc32(reconstructedCommitment);
+            if(txOutRecord.getTxOutAmountCommitmentData().size() > 0) {
+                final byte commitmentBytes[] = txOutRecord.getTxOutAmountCommitmentData().toByteArray();
+                if(reconstructedCrc32 != Util.computeCommittmentCrc32(commitmentBytes)) {
+                    throw(new SerializationException("Commitment CRC mismatch"));
+                }
+            }
+            else {
+                if(reconstructedCrc32 != txOutRecord.getTxOutAmountCommitmentDataCrc32()) {
+                    throw(new SerializationException("Commitment CRC mismatch"));
+                }
+            }
 
             MobileCoinAPI.TxOut.Builder txOutProtoBuilder = MobileCoinAPI.TxOut.newBuilder()
                     .setMaskedAmount(maskedAmount.toProtoBufObject())

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
@@ -8,7 +8,6 @@ import android.os.Parcelable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.google.protobuf.ByteString;
 import com.mobilecoin.api.MobileCoinAPI;
 import com.mobilecoin.api.MobileCoinAPI.EncryptedMemo;
 import com.mobilecoin.lib.exceptions.AmountDecoderException;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Util.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Util.java
@@ -4,7 +4,6 @@ package com.mobilecoin.lib;
 
 import androidx.annotation.NonNull;
 
-import com.google.protobuf.ByteString;
 import com.mobilecoin.lib.exceptions.TransactionBuilderException;
 import com.mobilecoin.lib.log.Logger;
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Util.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Util.java
@@ -4,6 +4,7 @@ package com.mobilecoin.lib;
 
 import androidx.annotation.NonNull;
 
+import com.google.protobuf.ByteString;
 import com.mobilecoin.lib.exceptions.TransactionBuilderException;
 import com.mobilecoin.lib.log.Logger;
 
@@ -92,4 +93,11 @@ final class Util extends Native {
         }
         return trustRoots;
     }
+
+    private static native int compute_commitment_crc32(byte committment_bytes[]);
+
+    static int computeCommittmentCrc32(byte committmentBytes[]) {
+        return compute_commitment_crc32(committmentBytes);
+    }
+
 }

--- a/android-sdk/versions.gradle
+++ b/android-sdk/versions.gradle
@@ -28,7 +28,7 @@ versions.network = network_versions
 
 // JNI
 def jni_versions = [:]
-jni_versions.mobilecoin = '1.2.1'
+jni_versions.mobilecoin = '1.2.2'
 versions.jni = jni_versions
 
 // Testing


### PR DESCRIPTION
### Motivation

For TxOutRecords without commitment data, the commitment must be reconstructed. This PR computes the CRC of the reconstructed commitment and ensures it matches the CRC data in the TxOutRecord.

### In this PR
* Verification of reconstructed commitment data
