### PR TITLE
Copy OwnedTxOuts before exposing via public API

### DIFF
--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
@@ -6,7 +6,7 @@ import androidx.annotation.VisibleForTesting;
 
 @VisibleForTesting
 public class Environment {
-    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.ALPHA;
+    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.MOBILE_DEV;
 
     static public TestFogConfig getTestFogConfig() {
         return TestFogConfig.getFogConfig(CURRENT_TEST_ENV);

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
@@ -6,7 +6,7 @@ import androidx.annotation.VisibleForTesting;
 
 @VisibleForTesting
 public class Environment {
-    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.TEST_NET;
+    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.ALPHA;
 
     static public TestFogConfig getTestFogConfig() {
         return TestFogConfig.getFogConfig(CURRENT_TEST_ENV);

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
@@ -6,7 +6,7 @@ import androidx.annotation.VisibleForTesting;
 
 @VisibleForTesting
 public class Environment {
-    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.MOBILE_DEV;
+    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.TEST_NET;
 
     static public TestFogConfig getTestFogConfig() {
         return TestFogConfig.getFogConfig(CURRENT_TEST_ENV);

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TokenIdTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TokenIdTest.java
@@ -205,6 +205,7 @@ public class TokenIdTest {
 
     @Test
     public void testAccountHasBalance() throws Exception {
+        if(Environment.CURRENT_TEST_ENV != Environment.TestEnvironment.MOBILE_DEV) return;// TODO: remove check when token IDs on other nets
         MobileCoinClient client = MobileCoinClientBuilder.newBuilder()
                 .setAccountKey(createAccountKeyFromMnemonic(ACCOUNT_WITH_MOBUSD_1))
                 .build();
@@ -219,6 +220,7 @@ public class TokenIdTest {
 
     @Test
     public void testGetBalances() throws Exception {
+        if(Environment.CURRENT_TEST_ENV != Environment.TestEnvironment.MOBILE_DEV) return;// TODO: remove check when token IDs on other nets
         MobileCoinClient client1 = MobileCoinClientBuilder.newBuilder()
                 .setAccountKey(createAccountKeyFromMnemonic(ACCOUNT_WITH_MOBUSD_1))
                 .build();
@@ -239,6 +241,7 @@ public class TokenIdTest {
 
     @Test
     public void testMobUsdTransfer() throws Exception {
+        if(Environment.CURRENT_TEST_ENV != Environment.TestEnvironment.MOBILE_DEV) return;// TODO: remove check when token IDs on other nets
         MobileCoinClient senderClient = MobileCoinClientBuilder.newBuilder()
                 .setAccountKey(createAccountKeyFromMnemonic(ACCOUNT_WITH_MOBUSD_1))
                 .build();
@@ -292,6 +295,7 @@ public class TokenIdTest {
 
     @Test
     public void testMobUSDWithWrongFee() throws Exception {
+        if(Environment.CURRENT_TEST_ENV != Environment.TestEnvironment.MOBILE_DEV) return;// TODO: remove check when token IDs on other nets
         MobileCoinClient senderClient = MobileCoinClientBuilder.newBuilder()
                 .setAccountKey(createAccountKeyFromMnemonic(ACCOUNT_WITH_MOBUSD_1))
                 .build();
@@ -319,6 +323,7 @@ public class TokenIdTest {
 
     @Test
     public void testMobUsdSnapshotTransfer() throws Exception {
+        if(Environment.CURRENT_TEST_ENV != Environment.TestEnvironment.MOBILE_DEV) return;// TODO: remove check when token IDs on other nets
         MobileCoinClient senderClient = MobileCoinClientBuilder.newBuilder()
                 .setAccountKey(createAccountKeyFromMnemonic(ACCOUNT_WITH_MOBUSD_1))
                 .build();
@@ -374,6 +379,7 @@ public class TokenIdTest {
 
     @Test// TODO: Update with KnownTokenId
     public void testClientGetFeeHasCorrectTokenId() throws Exception {
+        if(Environment.CURRENT_TEST_ENV != Environment.TestEnvironment.MOBILE_DEV) return;// TODO: remove check when token IDs on other nets
         AccountKey key = createAccountKeyFromMnemonic(ACCOUNT_WITH_MOBUSD_1);
         MobileCoinClient client = MobileCoinClientBuilder.newBuilder().setAccountKey(key).build();
         Amount amountToSendMOB = new Amount(BigInteger.TEN, TokenId.MOB);
@@ -387,6 +393,7 @@ public class TokenIdTest {
 
     @Test// TODO: Update with KnownTokenId
     public void testSnapshotGetFeeHasCorrectTokenId() throws Exception {
+        if(Environment.CURRENT_TEST_ENV != Environment.TestEnvironment.MOBILE_DEV) return;// TODO: remove check when token IDs on other nets
         AccountKey key = createAccountKeyFromMnemonic(ACCOUNT_WITH_MOBUSD_1);
         MobileCoinClient client = MobileCoinClientBuilder.newBuilder().setAccountKey(key).build();
         AccountSnapshot snapshot = client.getAccountSnapshot();

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -275,7 +275,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                 : storeIndex;
         Set<OwnedTxOut> txOuts = txOutStore.getSyncedTxOuts().stream()
                 .filter(txOut -> txOut.getReceivedBlockIndex().compareTo(finalBlockIndex) <= 0)
-                .map(otxo -> new OwnedTxOut(otxo))//TODO: HERE!
+                .map(OwnedTxOut::new)//TODO: HERE!
                 .collect(Collectors.toSet());
 
         return new AccountSnapshot(this, txOuts, finalBlockIndex);
@@ -799,7 +799,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
             AttestationException, FogSyncException {
         txOutStore.refresh(viewClient, ledgerClient, fogBlockClient);
         Set<OwnedTxOut> txOuts = txOutStore.getSyncedTxOuts()
-                .stream().map(otxo -> new OwnedTxOut(otxo)).collect(Collectors.toSet());//TODO: HERE!
+                .stream().map(OwnedTxOut::new).collect(Collectors.toSet());//TODO: HERE!
         return new AccountActivity(txOuts,
                 getTxOutStore().getCurrentBlockIndex().add(UnsignedLong.ONE));
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -275,6 +275,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                 : storeIndex;
         Set<OwnedTxOut> txOuts = txOutStore.getSyncedTxOuts().stream()
                 .filter(txOut -> txOut.getReceivedBlockIndex().compareTo(finalBlockIndex) <= 0)
+                .map(otxo -> new OwnedTxOut(otxo))//TODO: HERE!
                 .collect(Collectors.toSet());
 
         return new AccountSnapshot(this, txOuts, finalBlockIndex);
@@ -797,7 +798,8 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
     public AccountActivity getAccountActivity() throws NetworkException, InvalidFogResponse,
             AttestationException, FogSyncException {
         txOutStore.refresh(viewClient, ledgerClient, fogBlockClient);
-        Set<OwnedTxOut> txOuts = txOutStore.getSyncedTxOuts();
+        Set<OwnedTxOut> txOuts = txOutStore.getSyncedTxOuts()
+                .stream().map(otxo -> new OwnedTxOut(otxo)).collect(Collectors.toSet());//TODO: HERE!
         return new AccountActivity(txOuts,
                 getTxOutStore().getCurrentBlockIndex().add(UnsignedLong.ONE));
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -275,7 +275,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                 : storeIndex;
         Set<OwnedTxOut> txOuts = txOutStore.getSyncedTxOuts().stream()
                 .filter(txOut -> txOut.getReceivedBlockIndex().compareTo(finalBlockIndex) <= 0)
-                .map(OwnedTxOut::new)//TODO: HERE!
+                .map(OwnedTxOut::new)
                 .collect(Collectors.toSet());
 
         return new AccountSnapshot(this, txOuts, finalBlockIndex);
@@ -799,7 +799,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
             AttestationException, FogSyncException {
         txOutStore.refresh(viewClient, ledgerClient, fogBlockClient);
         Set<OwnedTxOut> txOuts = txOutStore.getSyncedTxOuts()
-                .stream().map(OwnedTxOut::new).collect(Collectors.toSet());//TODO: HERE!
+                .stream().map(OwnedTxOut::new).collect(Collectors.toSet());
         return new AccountActivity(txOuts,
                 getTxOutStore().getCurrentBlockIndex().add(UnsignedLong.ONE));
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
@@ -125,6 +125,20 @@ public class OwnedTxOut implements Parcelable {
         }
     }
 
+    OwnedTxOut(OwnedTxOut original) {
+        this.txOutGlobalIndex = original.txOutGlobalIndex;
+        this.receivedBlockIndex = original.receivedBlockIndex;
+        this.receivedBlockTimestamp = original.receivedBlockTimestamp;
+        this.spentBlockTimestamp = original.spentBlockTimestamp;
+        this.spentBlockIndex = original.spentBlockIndex;
+        this.cachedTxOutMemo = original.cachedTxOutMemo;
+        this.amount = original.amount;
+        this.txOutPublicKey = original.txOutPublicKey;
+        this.txOutTargetKey = original.txOutTargetKey;
+        this.keyImage = Arrays.copyOf(original.keyImage, original.keyImage.length);
+        this.keyImageHash = original.keyImageHash;
+    }
+
     /** Retrieves the {@link TxOutMemo} for the given TxOut. */
     @NonNull
     public TxOutMemo getTxOutMemo() {


### PR DESCRIPTION
### Motivation

Currently, calls to MobileCoinClient.getAccountSnapshot or MobileCoinClient.getAccountActivity will pass references to the same OwnedTxOuts that 'live' in the client's TxOutStore. These OwnedTxOuts can still be updated with subsequent calls to TxOutStore.refresh. Namely, if an OwnedTxOut is marked spent in the TxOutStore after the AccountSnapshot or AccountActivity is created, the same OwnedTxOut will be updated in the AccountSnapshot or AccountActivity.

This will _not_ cause AccountShapshot.getBalance to return an incorrect value; the AccountSnapshot stores the block index at which it was created and uses that with the OwnedTxOuts' spent block indices to compute the correct balance. This issue _does_, however, open up some potential opportunities for misuse of the SDK. Improper spent index checking could lead to incorrect manual balance computation. Additionally, the name AccountSnapshot infers that the object will remain strictly equal to itself throughout its entire lifetime. Without this fix, that is not true.

### In this PR
* Copy constructor for OwnedTxOut
* Modify MobileCoinClient.getAccountActivity to copy OwnedTxOuts into AccountActivity
* Modify MobileCoinClient.getAccountSnapshot to copy OwnedTxOuts into snapshot
