### PR TITLE
make message of InvalidTransactionException public

### DIFF
--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -567,9 +567,8 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         int code = txResponse.getResult().getNumber();
         if (0 != code) {
             blockchainClient.resetCache();
-            String message = txResponse.getResult().toString();
             InvalidTransactionException invalidTransactionException =
-                    new InvalidTransactionException(message);
+                    new InvalidTransactionException(txResponse.getResult());
             Util.logException(TAG, invalidTransactionException);
             throw invalidTransactionException;
         }
@@ -718,7 +717,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                     throw illegalStateException;
                 }
                 if (status == Receipt.Status.FAILED) {
-                    throw new InvalidTransactionException("Defrag step transaction has failed");
+                    throw new TransactionBuilderException("Defrag step transaction has failed");
                 }
             }
         } while (inputSelectionForAmount == null);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidTransactionException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidTransactionException.java
@@ -2,10 +2,12 @@
 
 package com.mobilecoin.lib.exceptions;
 
-import androidx.annotation.Nullable;
-
 public final class InvalidTransactionException extends MobileCoinException {
-    public InvalidTransactionException(@Nullable String message) {
+    public final String message;
+
+    public InvalidTransactionException(String message) {
         super(message);
+
+        this.message = message;
     }
 }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidTransactionException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidTransactionException.java
@@ -2,12 +2,20 @@
 
 package com.mobilecoin.lib.exceptions;
 
+import androidx.annotation.NonNull;
+
+import consensus_common.ConsensusCommon;
+
 public final class InvalidTransactionException extends MobileCoinException {
-    public final String message;
+    public final ConsensusCommon.ProposeTxResult result;
 
-    public InvalidTransactionException(String message) {
-        super(message);
+    public InvalidTransactionException(@NonNull ConsensusCommon.ProposeTxResult result) {
+        super(result.toString());
 
-        this.message = message;
+        this.result = result;
+    }
+
+    public ConsensusCommon.ProposeTxResult getResult() {
+        return this.result;
     }
 }


### PR DESCRIPTION
### Motivation

To have parody with iOS, we need to make the error message public. This also makes it so clients can interpret the error code and handle it accordingly.

### In this PR

- Makes the `message` attribute public on `InvalidTransactionException`

