### PR TITLE
Unit tests and gradle update

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -118,6 +118,7 @@ dependencies {
 
     // Testing
     testImplementation deps.testing.junit
+    testImplementation deps.testing.robolectric
     testImplementation deps.testing.mockito_core
     androidTestImplementation deps.testing.mockito_android
     androidTestImplementation deps.testing.core

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/MobileCoinClientTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/MobileCoinClientTest.java
@@ -23,6 +23,7 @@ import com.mobilecoin.lib.exceptions.NetworkException;
 import com.mobilecoin.lib.log.Logger;
 import com.mobilecoin.lib.network.TransportProtocol;
 import com.mobilecoin.lib.network.uri.FogUri;
+import com.mobilecoin.lib.util.SimpleRequester;
 
 import org.junit.Assert;
 import org.junit.Rule;

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/util/SimpleRequester.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/util/SimpleRequester.java
@@ -1,4 +1,4 @@
-package com.mobilecoin.lib;
+package com.mobilecoin.lib.util;
 
 import android.net.Uri;
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AccountSnapshot.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AccountSnapshot.java
@@ -181,7 +181,7 @@ public final class AccountSnapshot {
         if (keyMapping.isEmpty()) {
             Set<RistrettoPublic> outputPublicKeys = transaction.getOutputPublicKeys();
             Ledger.TxOutResponse response =
-                    mobileCoinClient.untrustedClient.fetchTxOuts(outputPublicKeys);
+                    mobileCoinClient.getUntrustedClient().fetchTxOuts(outputPublicKeys);
             List<Ledger.TxOutResult> results = response.getResultsList();
 
             boolean allTxOutsFound = true;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -192,6 +192,11 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         this.blockchainClient = blockchainClient;
     }
 
+    @NonNull
+    FogUntrustedClient getUntrustedClient() {
+        return untrustedClient;
+    }
+
     private List<MobileCoinUri> createNormalizedConsensusUris(List<Uri> consensusUris)
         throws InvalidUriException {
         List<MobileCoinUri> normalizedConsensusUris = new ArrayList<>();
@@ -925,7 +930,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                 username,
                 password
         );
-        untrustedClient.setAuthorization(
+        getUntrustedClient().setAuthorization(
                 username,
                 password
         );
@@ -950,7 +955,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         consensusClient.setTransportProtocol(protocol);
         blockchainClient.setTransportProtocol(protocol);
         fogBlockClient.setTransportProtocol(protocol);
-        untrustedClient.setTransportProtocol(protocol);
+        getUntrustedClient().setTransportProtocol(protocol);
         fogReportsManager.setTransportProtocol(protocol);
     }
 
@@ -971,9 +976,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         if (null != blockchainClient) {
             blockchainClient.shutdown();
         }
-        if (null != untrustedClient) {
-            untrustedClient.shutdown();
-        }
+        getUntrustedClient().shutdown();
     }
 
     @Override

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Native.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Native.java
@@ -2,12 +2,19 @@
 
 package com.mobilecoin.lib;
 
+import com.mobilecoin.lib.log.Logger;
+
 class Native {
     private final static String MOBILECOIN_LIB_NAME = "mobilecoin";
+    private static final String TAG = Native.class.toString();
 
     // Load JNI lib
     static {
-        System.loadLibrary(MOBILECOIN_LIB_NAME);
+        try {
+            System.loadLibrary(MOBILECOIN_LIB_NAME);
+        } catch (UnsatisfiedLinkError error) {
+            Logger.wtf(TAG, "Unable to load mobilecoin library", error);
+        }
     }
 
     protected long rustObj = 0;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/Requester/HttpRequester.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/Requester/HttpRequester.java
@@ -77,7 +77,7 @@ public class HttpRequester implements Requester {
 
     @NonNull
     @VisibleForTesting
-    public HttpURLConnection createConnection(@NonNull String httpMethod,
+    HttpURLConnection createConnection(@NonNull String httpMethod,
                                               @NonNull Uri uri,
                                               @NonNull Map<String, String> headers,
                                               @NonNull byte[] body,

--- a/android-sdk/src/test/java/com/mobilecoin/lib/AccountSnapshotTests.java
+++ b/android-sdk/src/test/java/com/mobilecoin/lib/AccountSnapshotTests.java
@@ -1,0 +1,288 @@
+package com.mobilecoin.lib;
+
+import static com.mobilecoin.lib.TokenId.MOB;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.mobilecoin.lib.exceptions.AmountDecoderException;
+import com.mobilecoin.lib.exceptions.AttestationException;
+import com.mobilecoin.lib.exceptions.FeeRejectedException;
+import com.mobilecoin.lib.exceptions.FogReportException;
+import com.mobilecoin.lib.exceptions.FogSyncException;
+import com.mobilecoin.lib.exceptions.FragmentedAccountException;
+import com.mobilecoin.lib.exceptions.InsufficientFundsException;
+import com.mobilecoin.lib.exceptions.InvalidFogResponse;
+import com.mobilecoin.lib.exceptions.InvalidReceiptException;
+import com.mobilecoin.lib.exceptions.NetworkException;
+import com.mobilecoin.lib.exceptions.TransactionBuilderException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.robolectric.RobolectricTestRunner;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import fog_ledger.Ledger;
+
+@RunWith(RobolectricTestRunner.class)
+public class AccountSnapshotTests {
+
+    private final KeyImage keyImage1 = mock(KeyImage.class);
+    private final KeyImage keyImage2 = mock(KeyImage.class);
+    private final BigInteger amountTen = BigInteger.TEN;
+    private final BigInteger amountZero = BigInteger.ZERO;
+    private final BigInteger amountOne = BigInteger.ONE;
+    private final UnsignedLong blockIndexOne = UnsignedLong.ONE;
+    private final UnsignedLong blockIndexZero = UnsignedLong.ZERO;
+    private final UnsignedLong blockIndexTen = UnsignedLong.TEN;
+    private static final Amount TEN_MOB = createAmountMOB(BigInteger.TEN);
+    private static final Amount ONE_MOB = createAmountMOB(BigInteger.ONE);
+
+    @Test
+    public void test_balance() {
+        Set<OwnedTxOut> txOuts = createMockTxOut();
+
+        AccountSnapshot accountSnapshot = new AccountSnapshot(mock(MobileCoinClient.class), txOuts, blockIndexOne);
+
+        assertEquals(new Balance(amountTen, blockIndexOne), accountSnapshot.getBalance(MOB));
+    }
+
+    @Test
+    public void retrieve_block_index() {
+        Set<OwnedTxOut> txOuts = createMockTxOut();
+
+        AccountSnapshot accountSnapshot = new AccountSnapshot(mock(MobileCoinClient.class), txOuts, blockIndexOne);
+
+        assertEquals(blockIndexOne, accountSnapshot.getBlockIndex());
+    }
+
+    @Test
+    public void transaction_receipts_unknown_status() throws InvalidReceiptException {
+        Set<OwnedTxOut> txOuts = createMockTxOut();
+        Receipt receipt = createMockReceipt(blockIndexTen);
+
+        AccountSnapshot accountSnapshot = new AccountSnapshot(mock(MobileCoinClient.class), txOuts, blockIndexOne);
+
+        assertEquals(Receipt.Status.UNKNOWN, accountSnapshot.getReceiptStatus(receipt));
+        assertEquals(blockIndexOne, accountSnapshot.getReceiptStatus(receipt).getBlockIndex());
+    }
+
+    @Test
+    public void transaction_receipts_failed_status() throws InvalidReceiptException {
+        Set<OwnedTxOut> txOuts = createMockTxOut();
+        Receipt receipt = createMockReceipt(blockIndexOne);
+
+        AccountSnapshot accountSnapshot = new AccountSnapshot(mock(MobileCoinClient.class), txOuts, blockIndexOne);
+        assertEquals(Receipt.Status.FAILED, accountSnapshot.getReceiptStatus(receipt));
+        assertEquals(blockIndexOne, accountSnapshot.getReceiptStatus(receipt).getBlockIndex());
+    }
+
+    @Test
+    public void transaction_receipts_received_status() throws InvalidReceiptException, AmountDecoderException {
+        Set<OwnedTxOut> txOuts = new HashSet<>();
+        OwnedTxOut txOut = mock(OwnedTxOut.class);
+        when(txOut.getAmount()).thenReturn(new Amount(amountTen, MOB));
+        RistrettoPublic ristrettoPublic = mock(RistrettoPublic.class);
+        when(txOut.getPublicKey()).thenReturn(ristrettoPublic);
+        when(txOut.getReceivedBlockIndex()).thenReturn(blockIndexOne);
+        txOuts.add(txOut);
+        Receipt receipt = mock(Receipt.class);
+        when(receipt.getPublicKey()).thenReturn(ristrettoPublic);
+        when(receipt.getAmountData(any())).thenReturn(new Amount(amountTen, MOB));
+        when(receipt.getTombstoneBlockIndex()).thenReturn(blockIndexOne);
+
+        AccountSnapshot accountSnapshot = new AccountSnapshot(mock(MobileCoinClient.class), txOuts, blockIndexOne);
+
+        assertEquals(Receipt.Status.RECEIVED, accountSnapshot.getReceiptStatus(receipt));
+        assertEquals(blockIndexOne, accountSnapshot.getReceiptStatus(receipt).getBlockIndex());
+    }
+
+    @Test
+    public void transaction_receipt_unknown_status() throws InvalidReceiptException {
+        Receipt receipt = createMockReceipt(blockIndexOne);
+
+        AccountSnapshot accountSnapshot = new AccountSnapshot(mock(MobileCoinClient.class), new HashSet<>(), blockIndexZero);
+
+        assertEquals(Receipt.Status.UNKNOWN, accountSnapshot.getReceiptStatus(receipt));
+        assertEquals(blockIndexZero, accountSnapshot.getReceiptStatus(receipt).getBlockIndex());
+    }
+
+    @Test
+    public void transferable_amount() {
+        Set<OwnedTxOut> txOuts = createMockTxOuts(false);
+
+        AccountSnapshot accountSnapshot = new AccountSnapshot(mock(MobileCoinClient.class), txOuts, blockIndexOne);
+
+        assertEquals(amountTen, accountSnapshot.getTransferableAmount(amountOne));
+    }
+
+    @Test
+    public void transferable_amount_zero() {
+        Set<OwnedTxOut> txOuts = createMockTxOuts(true);
+
+        AccountSnapshot accountSnapshot = new AccountSnapshot(mock(MobileCoinClient.class), txOuts, blockIndexOne);
+
+        assertEquals(amountZero, accountSnapshot.getTransferableAmount(amountOne));
+    }
+
+    @Test
+    public void estimate_total_fee() throws InsufficientFundsException {
+        Set<OwnedTxOut> txOuts = createMockTxOuts(false);
+
+        AccountSnapshot accountSnapshot = new AccountSnapshot(mock(MobileCoinClient.class), txOuts, blockIndexOne);
+
+        assertEquals(amountOne, accountSnapshot.estimateTotalFee(amountTen, amountOne));
+    }
+
+    @Test
+    public void estimate_total_fees() throws InsufficientFundsException {
+        Set<OwnedTxOut> txOuts = createMockTxOuts(false);
+        try (MockedStatic<UTXOSelector> selector = mockStatic(UTXOSelector.class)) {
+            selector.when(() -> UTXOSelector.calculateFee(any(), any(), any(), any(), any(), anyInt())).thenReturn(amountOne);
+
+            AccountSnapshot accountSnapshot = new AccountSnapshot(mock(MobileCoinClient.class), txOuts, blockIndexOne);
+
+            assertEquals(createAmountMOB(amountOne), accountSnapshot.estimateTotalFee(TEN_MOB, ONE_MOB));
+        }
+
+    }
+
+    @Test
+    public void prepare_transaction() throws InsufficientFundsException, FragmentedAccountException, AttestationException, FogReportException, FeeRejectedException, FogSyncException, InvalidFogResponse, NetworkException, TransactionBuilderException {
+        Set<OwnedTxOut> txOuts = createMockTxOuts(false);
+        MobileCoinClient client = mock(MobileCoinClient.class);
+        PublicAddress publicAddress = mock(PublicAddress.class);
+        TxOutMemoBuilder memoBuilder = mock(TxOutMemoBuilder.class);
+        PendingTransaction expectedTransaction = mock(PendingTransaction.class);
+        when(client.prepareTransaction(eq(publicAddress), eq(TEN_MOB), any(), eq(ONE_MOB), eq(memoBuilder))).thenReturn(expectedTransaction);
+
+        AccountSnapshot accountSnapshot = new AccountSnapshot(client, txOuts, blockIndexOne);
+
+        assertEquals(expectedTransaction, accountSnapshot.prepareTransaction(publicAddress, TEN_MOB, ONE_MOB, memoBuilder));
+    }
+
+    @Test
+    public void transaction_status_unknown() throws NetworkException {
+        Transaction transaction = createMockTransaction();
+        Set<OwnedTxOut> txOuts = createMockTxOut();
+        MobileCoinClient client = mock(MobileCoinClient.class);
+
+        AccountSnapshot accountSnapshot = new AccountSnapshot(client, txOuts, blockIndexOne);
+
+        assertEquals(Transaction.Status.UNKNOWN, accountSnapshot.getTransactionStatus(transaction));
+    }
+
+    @Test
+    public void transaction_status_failed() throws NetworkException {
+        Transaction transaction = createMockTransaction();
+        Set<OwnedTxOut> txOuts = createMockTxOut();
+        MobileCoinClient client = mock(MobileCoinClient.class);
+
+        AccountSnapshot accountSnapshot = new AccountSnapshot(client, txOuts, blockIndexTen);
+
+        assertEquals(Transaction.Status.FAILED, accountSnapshot.getTransactionStatus(transaction));
+    }
+
+    @Test
+    public void transaction_status_accepted() throws NetworkException {
+        Transaction transaction = createMockTransaction();
+        Set<OwnedTxOut> txOuts = createMockTxOutsWithKeyImage(true);
+        MobileCoinClient client = mock(MobileCoinClient.class);
+        FogUntrustedClient untrustedClient = mock(FogUntrustedClient.class);
+        when(client.getUntrustedClient()).thenReturn(untrustedClient);
+        Ledger.TxOutResponse txOutResponse = mock(Ledger.TxOutResponse.class);
+        when(untrustedClient.fetchTxOuts(any())).thenReturn(txOutResponse);
+        List<Ledger.TxOutResult> results = new ArrayList<>();
+        Ledger.TxOutResult res = mock(Ledger.TxOutResult.class);
+        when(res.getResultCode()).thenReturn(Ledger.TxOutResultCode.Found);
+        long index = 2;
+        when(res.getBlockIndex()).thenReturn(index);
+        results.add(res);
+        when(txOutResponse.getResultsList()).thenReturn(results);
+
+        AccountSnapshot accountSnapshot = new AccountSnapshot(client, txOuts, blockIndexTen);
+
+        assertEquals(Transaction.Status.ACCEPTED, accountSnapshot.getTransactionStatus(transaction));
+    }
+
+    public static Amount createAmountMOB(BigInteger amount) {
+        return new Amount(amount, MOB);
+    }
+
+    public Set<OwnedTxOut> createMockTxOuts(boolean isSpent) {
+        Set<OwnedTxOut> txOuts = new HashSet<>();
+        OwnedTxOut txOut_1 = mock(OwnedTxOut.class);
+        when(txOut_1.getAmount()).thenReturn(createAmountMOB(amountTen));
+        when(txOut_1.isSpent(blockIndexOne)).thenReturn(isSpent);
+        OwnedTxOut txOut_2 = mock(OwnedTxOut.class);
+        when(txOut_2.getAmount()).thenReturn(createAmountMOB(amountOne));
+        when(txOut_2.isSpent(blockIndexOne)).thenReturn(isSpent);
+        txOuts.add(txOut_1);
+        txOuts.add(txOut_2);
+        return txOuts;
+    }
+
+    public Set<OwnedTxOut> createMockTxOutsWithKeyImage(boolean isSpent) {
+        Set<OwnedTxOut> txOuts = new HashSet<>();
+        OwnedTxOut txOut_1 = mock(OwnedTxOut.class);
+        when(txOut_1.getAmount()).thenReturn(TEN_MOB);
+        when(txOut_1.isSpent(blockIndexTen)).thenReturn(isSpent);
+        when(txOut_1.getKeyImage()).thenReturn(keyImage1);
+        OwnedTxOut txOut_2 = mock(OwnedTxOut.class);
+        when(txOut_2.getAmount()).thenReturn(ONE_MOB);
+        when(txOut_2.isSpent(blockIndexTen)).thenReturn(isSpent);
+        when(txOut_2.getKeyImage()).thenReturn(keyImage2);
+        txOuts.add(txOut_1);
+        txOuts.add(txOut_2);
+        return txOuts;
+    }
+
+    public Set<OwnedTxOut> createMockTxOut() {
+        Set<OwnedTxOut> txOuts = new HashSet<>();
+        OwnedTxOut txOut = mock(OwnedTxOut.class);
+        when(txOut.getAmount()).thenReturn(TEN_MOB);
+        RistrettoPublic ristrettoPublic = mock(RistrettoPublic.class);
+        when(txOut.getPublicKey()).thenReturn(ristrettoPublic);
+        when(txOut.getKeyImage()).thenReturn(keyImage1);
+        txOuts.add(txOut);
+        return txOuts;
+    }
+
+    public Receipt createMockReceipt(UnsignedLong tomstoneBlockIndex) {
+        Receipt receipt = mock(Receipt.class);
+        RistrettoPublic ristrettoPublic = mock(RistrettoPublic.class);
+        when(receipt.getPublicKey()).thenReturn(ristrettoPublic);
+        when(receipt.getTombstoneBlockIndex()).thenReturn(tomstoneBlockIndex);
+        return receipt;
+    }
+
+    public Transaction createMockTransaction() {
+        Transaction transaction = mock(Transaction.class);
+        when(transaction.getKeyImages()).thenReturn(createMockKeyImage());
+        long TOMBSTONE_INDEX = 3;
+        when(transaction.getTombstoneBlockIndex()).thenReturn(TOMBSTONE_INDEX);
+        RistrettoPublic ristrettoPublic = mock(RistrettoPublic.class);
+        Set<RistrettoPublic> outputPublicKeys = new HashSet<>();
+        outputPublicKeys.add(ristrettoPublic);
+        when(transaction.getOutputPublicKeys()).thenReturn(outputPublicKeys);
+        return transaction;
+    }
+
+    public Set<KeyImage> createMockKeyImage() {
+        Set<KeyImage> keyImages = new HashSet<>();
+        keyImages.add(keyImage1);
+        keyImages.add(keyImage2);
+        return keyImages;
+    }
+
+}

--- a/android-sdk/src/test/java/com/mobilecoin/lib/network/services/http/Requester/HttpRequesterTest.java
+++ b/android-sdk/src/test/java/com/mobilecoin/lib/network/services/http/Requester/HttpRequesterTest.java
@@ -1,3 +1,5 @@
+package com.mobilecoin.lib.network.services.http.Requester;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -8,10 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.net.Uri;
-
-import com.mobilecoin.lib.network.services.http.Requester.HttpRequester;
-import com.mobilecoin.lib.network.services.http.Requester.Requester;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/android-sdk/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/android-sdk/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/android-sdk/versions.gradle
+++ b/android-sdk/versions.gradle
@@ -3,7 +3,7 @@ ext.deps = [:]
 def deps = [:]
 def versions = [:]
 
-versions.gradle_plugin = '4.2.1'
+versions.gradle_plugin = '7.1.3'
 versions.protobuf_gradle_plugin = '0.8.16'
 
 def build_versions = [:]
@@ -40,6 +40,7 @@ testing_versions.ext_junit = '1.1.3'
 testing_versions.espresso_core = '3.4.0'
 testing_versions.support_rules = '1.0.2'
 testing_versions.okhttp = '2.7.4'
+testing_versions.robolectric = '4.8'
 versions.testing = testing_versions
 
 deps.gradle_plugin = "com.android.tools.build:gradle:$versions.gradle_plugin"
@@ -79,6 +80,7 @@ testing_deps.rules = "androidx.test:rules:$versions.testing.core"
 testing_deps.espresso_core = "androidx.test.espresso:espresso-core:$versions.testing.espresso_core"
 testing_deps.support_rules = "com.android.support.test:rules:$versions.testing.support_rules"
 testing_deps.okhttp = "com.squareup.okhttp:okhttp:$versions.testing.okhttp"
+testing_deps.robolectric = "org.robolectric:robolectric:$versions.testing.robolectric"
 deps.testing = testing_deps
 
 ext.deps = deps

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:6.7.1-jdk8
+FROM gradle:7.2-jdk11
 USER root
 ENV SDK_URL="https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip" \
     ANDROID_HOME="/usr/local/android-sdk" \

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip


### PR DESCRIPTION
### Motivation

Prior to this change, unit tests were run as instrumented tests which are usually slow. 
Robolectric library is used to run the unit tests in this PR. The library extends Android framework APIs and runs the code in sandbox. This lets us test each method in isolation and the tests are faster as it does not have to install/run on an emulator. 

### In this PR
Upgraded gradle to 7.2
Updated DockerFile to use gradle 7.2 JDK 11
Added roboelectric library
Added unit tests for AccountSnapshot

### Future Work
Add unit tests for other files
Use instrumented tests for testing a complete flow (e.g. submit transaction, view balance)