### PR TITLE
Add ProposeTxResult to InvalidTransactionException

### DIFF
--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -564,12 +564,12 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         ConsensusCommon.ProposeTxResponse txResponse =
                 consensusClient.proposeTx(transaction.toProtoBufObject());
         this.txOutStore.setConsensusBlockIndex(UnsignedLong.fromLongBits(txResponse.getBlockCount() - 1L));
-        int code = txResponse.getResult().getNumber();
+        ConsensusCommon.ProposeTxResult txResult = txResponse.getResult();
+        int code = txResult.getNumber();
         if (0 != code) {
             blockchainClient.resetCache();
-            String message = txResponse.getResult().toString();
             InvalidTransactionException invalidTransactionException =
-                    new InvalidTransactionException(message);
+                    new InvalidTransactionException(txResult);
             Util.logException(TAG, invalidTransactionException);
             throw invalidTransactionException;
         }
@@ -696,29 +696,22 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                     return;
                 }
                 // make sure the previous Tx is posted
-                Receipt.Status status;
+                Transaction.Status status;
                 int queryTries = 0;
-                try {
-                    while ((status = getReceiptStatus(pendingTransaction.getReceipt()))
-                            == Receipt.Status.UNKNOWN) {
-                        if (queryTries++ == STATUS_MAX_RETRIES) {
-                            Logger.w(TAG, "Exceeded waiting time for the transaction to post");
-                            throw new TimeoutException();
-                        }
-                        try {
-                            Thread.sleep(STATUS_CHECK_DELAY_MS);
-                        } catch (InterruptedException interruptedException) {
-                            Logger.w(TAG, "Sleep interruption during defragmentation");
-                        }
+                while ((status = getTransactionStatus(pendingTransaction.getTransaction()))
+                        == Transaction.Status.UNKNOWN) {
+                    if (queryTries++ == STATUS_MAX_RETRIES) {
+                        Logger.w(TAG, "Exceeded waiting time for the transaction to post");
+                        throw new TimeoutException();
                     }
-                } catch (InvalidReceiptException invalidReceiptException) {
-                    IllegalStateException illegalStateException =
-                            new IllegalStateException(invalidReceiptException);
-                    Logger.e(TAG, "BUG: unreachable code", illegalStateException);
-                    throw illegalStateException;
+                    try {
+                        Thread.sleep(STATUS_CHECK_DELAY_MS);
+                    } catch (InterruptedException interruptedException) {
+                        Logger.w(TAG, "Sleep interruption during defragmentation");
+                    }
                 }
-                if (status == Receipt.Status.FAILED) {
-                    throw new InvalidTransactionException("Defrag step transaction has failed");
+                if (status == Transaction.Status.FAILED) {
+                    throw new InvalidTransactionException(ConsensusCommon.ProposeTxResult.TombstoneBlockExceeded);
                 }
             }
         } while (inputSelectionForAmount == null);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -711,6 +711,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                     }
                 }
                 if (status == Transaction.Status.FAILED) {
+                    //Status only set to FAILED on TombstoneBlockExceeded. See getTransactionStatus(Transaction transaction)
                     throw new InvalidTransactionException(ConsensusCommon.ProposeTxResult.TombstoneBlockExceeded);
                 }
             }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidTransactionException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidTransactionException.java
@@ -5,24 +5,69 @@ package com.mobilecoin.lib.exceptions;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.mobilecoin.lib.Amount;
+import com.mobilecoin.lib.DefragmentationDelegate;
+import com.mobilecoin.lib.PendingTransaction;
+import com.mobilecoin.lib.PublicAddress;
+import com.mobilecoin.lib.Transaction;
+import com.mobilecoin.lib.TxOutMemoBuilder;
+
+import java.math.BigInteger;
+
 import consensus_common.ConsensusCommon;
 
+/**
+ * This class represents a {@link MobileCoinException} that results from a failed/rejected
+ * {@link com.mobilecoin.lib.Transaction} proposal.
+ *
+ * @see com.mobilecoin.lib.Transaction
+ * @see com.mobilecoin.lib.MobileCoinClient#prepareTransaction(PublicAddress, Amount, Amount, TxOutMemoBuilder)
+ * @see com.mobilecoin.lib.MobileCoinAccountClient#defragmentAccount(Amount, DefragmentationDelegate, boolean)
+ * @see com.mobilecoin.lib.MobileCoinTransactionClient#submitTransaction(Transaction)
+ * @see DefragmentationDelegate#onStepReady(PendingTransaction, BigInteger)
+ * @see ConsensusCommon.ProposeTxResult
+ * @since 1.0.0
+ */
 public final class InvalidTransactionException extends MobileCoinException {
 
     @Nullable
     private final ConsensusCommon.ProposeTxResult result;
 
+    /**
+     * Creates an {@code InvalidTransactionException} with the given {@link ConsensusCommon.ProposeTxResult}.
+     *
+     * @param result the result of a {@link com.mobilecoin.lib.Transaction} proposal
+     * @see ConsensusCommon.ProposeTxResult
+     * @since 1.2.2
+     */
     public InvalidTransactionException(@NonNull ConsensusCommon.ProposeTxResult result) {
         super(result.toString());
         this.result = result;
     }
 
+    /**
+     * Creates an InvalidTransactionException with the specified message.
+     *
+     * @param message the {@link Exception} message
+     * @deprecated Deprecated as of 1.2.2. Please use
+     * {@link InvalidTransactionException#InvalidTransactionException(ConsensusCommon.ProposeTxResult)}.
+     * @see InvalidTransactionException#InvalidTransactionException(ConsensusCommon.ProposeTxResult).
+     * @see ConsensusCommon.ProposeTxResult
+     * @since 1.0.0
+     */
     @Deprecated
     public InvalidTransactionException(@Nullable String message) {
         super(message);
         this.result = null;
     }
 
+    /**
+     * Returns the {@link ConsensusCommon.ProposeTxResult} that caused this {@code InvalidTransactionException}.
+     *
+     * @return the failure reason for the {@link Transaction}
+     * @see ConsensusCommon.ProposeTxResult
+     * @since 1.2.2
+     */
     @Nullable
     public ConsensusCommon.ProposeTxResult getResult() {
         return this.result;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidTransactionException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidTransactionException.java
@@ -2,10 +2,30 @@
 
 package com.mobilecoin.lib.exceptions;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import consensus_common.ConsensusCommon;
+
 public final class InvalidTransactionException extends MobileCoinException {
+
+    @Nullable
+    private final ConsensusCommon.ProposeTxResult result;
+
+    public InvalidTransactionException(@NonNull ConsensusCommon.ProposeTxResult result) {
+        super(result.toString());
+        this.result = result;
+    }
+
+    @Deprecated
     public InvalidTransactionException(@Nullable String message) {
         super(message);
+        this.result = null;
     }
+
+    @Nullable
+    public ConsensusCommon.ProposeTxResult getResult() {
+        return this.result;
+    }
+
 }


### PR DESCRIPTION
### Motivation

This change is needed to make handling of different transaction errors easier. Prior to this, in order to handle different types of failures differently, String matching was required. With this change, enum value matching can be used.

### In this PR
* Add ProposeTxResult to InvalidTransactionException

