### PR TITLE
return consensus block index from submitTransaction

### DIFF
--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -578,7 +578,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
             Util.logException(TAG, invalidTransactionException);
             throw invalidTransactionException;
         }
-        return txResponse.getBlockCount();
+        return txResponse.getBlockCount() - 1;
     }
 
     @Override

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -562,7 +562,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
     }
 
     @Override
-    public void submitTransaction(@NonNull Transaction transaction)
+    public long submitTransaction(@NonNull Transaction transaction)
             throws InvalidTransactionException, NetworkException, AttestationException {
         Logger.i(TAG, "SubmitTransaction call", null,
                 "transaction:", transaction);
@@ -578,6 +578,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
             Util.logException(TAG, invalidTransactionException);
             throw invalidTransactionException;
         }
+        return txResponse.getBlockCount();
     }
 
     @Override

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
@@ -81,7 +81,7 @@ public interface MobileCoinTransactionClient {
    *
    * @param transaction a valid transaction object to submit (see {@link MobileCoinClient#prepareTransaction}}
    */
-  void submitTransaction(@NonNull Transaction transaction)
+  long submitTransaction(@NonNull Transaction transaction)
       throws InvalidTransactionException, NetworkException, AttestationException;
 
   /**


### PR DESCRIPTION
### Motivation

[task](https://www.pivotaltracker.com/story/show/182613898)

[comment on Moby Idempotence document](https://docs.google.com/document/d/1ayX6H_EjeCRVhu8lqUi7y1-D14RqyGDrewu70XcpYGY/edit?disco=AAAAbNCWhqI):

> Alex Voloshyn: 
> 1. KeyImages can be retrieved from TxOuts. (i.e. OwnedTxOut.getKeyImage)
> 2. Transaction object contains all KeyImages as a set (i.e. transaction.getKeyImages)
> 3. Fog View, Fog Ledger, and Consensus are all separate services with separate block heights. The SDK simplifies working with Fog by synchronizing View and Ledger block heights, but not consensus. So if you see that consensus is at block 1000 and it returns ContansSpentImages you will need to query Fog until it reports block height 1000 as well. (getTransactionStatus returns Status that contains current Fog block index, AccountSnapshot contains block index, etc). **SubmitTransaction does not return the consensus block index, so we will need to either add that or make BlockchainClient block height public to have it available at all times, not only after you submit**.

### In this PR
* return consensus block index from `submitTransaction`

