### PR TITLE
make sure block count is never below zero

### DIFF
--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -568,8 +568,8 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                 "transaction:", transaction);
         ConsensusCommon.ProposeTxResponse txResponse =
                 consensusClient.proposeTx(transaction.toProtoBufObject());
-        final long blockCount = txResponse.getBlockCount() > 0 ? txResponse.getBlockCount() - 1L : 0;
-        this.txOutStore.setConsensusBlockIndex(UnsignedLong.fromLongBits(blockCount));
+        final long blockIndex = txResponse.getBlockCount() > 0 ? txResponse.getBlockCount() - 1L : 0;
+        this.txOutStore.setConsensusBlockIndex(UnsignedLong.fromLongBits(blockIndex));
         ConsensusCommon.ProposeTxResult txResult = txResponse.getResult();
         int code = txResult.getNumber();
         if (0 != code) {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -575,7 +575,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         if (0 != code) {
             blockchainClient.resetCache();
             InvalidTransactionException invalidTransactionException =
-                    new InvalidTransactionException(txResult);
+                    new InvalidTransactionException(txResult, UnsignedLong.fromLongBits(blockIndex));
             Util.logException(TAG, invalidTransactionException);
             throw invalidTransactionException;
         }
@@ -719,7 +719,9 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                 }
                 if (status == Transaction.Status.FAILED) {
                     //Status only set to FAILED on TombstoneBlockExceeded. See getTransactionStatus(Transaction transaction)
-                    throw new InvalidTransactionException(ConsensusCommon.ProposeTxResult.TombstoneBlockExceeded);
+                    throw new InvalidTransactionException(
+                            ConsensusCommon.ProposeTxResult.TombstoneBlockExceeded,
+                            status.getBlockIndex());
                 }
             }
         } while (inputSelectionForAmount == null);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -579,7 +579,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
             Util.logException(TAG, invalidTransactionException);
             throw invalidTransactionException;
         }
-        return blockCount;
+        return blockIndex;
     }
 
     @Override

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -321,7 +321,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
             throw new NetworkException(NetworkResult.INTERNAL, e);
         }
     }
-    
+
     @Override
     @NonNull
     public Amount getTransferableAmount(@NonNull TokenId tokenId) throws NetworkException, InvalidFogResponse,
@@ -568,7 +568,8 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                 "transaction:", transaction);
         ConsensusCommon.ProposeTxResponse txResponse =
                 consensusClient.proposeTx(transaction.toProtoBufObject());
-        this.txOutStore.setConsensusBlockIndex(UnsignedLong.fromLongBits(txResponse.getBlockCount() - 1L));
+        final long blockCount = txResponse.getBlockCount() > 0 ? txResponse.getBlockCount() - 1L : 0;
+        this.txOutStore.setConsensusBlockIndex(UnsignedLong.fromLongBits(blockCount));
         ConsensusCommon.ProposeTxResult txResult = txResponse.getResult();
         int code = txResult.getNumber();
         if (0 != code) {
@@ -578,7 +579,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
             Util.logException(TAG, invalidTransactionException);
             throw invalidTransactionException;
         }
-        return txResponse.getBlockCount() - 1;
+        return blockCount;
     }
 
     @Override

--- a/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidTransactionException.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/exceptions/InvalidTransactionException.java
@@ -11,6 +11,7 @@ import com.mobilecoin.lib.PendingTransaction;
 import com.mobilecoin.lib.PublicAddress;
 import com.mobilecoin.lib.Transaction;
 import com.mobilecoin.lib.TxOutMemoBuilder;
+import com.mobilecoin.lib.UnsignedLong;
 
 import java.math.BigInteger;
 
@@ -32,17 +33,21 @@ public final class InvalidTransactionException extends MobileCoinException {
 
     @Nullable
     private final ConsensusCommon.ProposeTxResult result;
+    @Nullable
+    private final UnsignedLong blockIndex;
 
     /**
      * Creates an {@code InvalidTransactionException} with the given {@link ConsensusCommon.ProposeTxResult}.
      *
-     * @param result the result of a {@link com.mobilecoin.lib.Transaction} proposal
+     * @param result the result of a {@link Transaction} proposal
+     * @param blockIndex the blockIndex from consensus
      * @see ConsensusCommon.ProposeTxResult
      * @since 1.2.2
      */
-    public InvalidTransactionException(@NonNull ConsensusCommon.ProposeTxResult result) {
+    public InvalidTransactionException(@NonNull ConsensusCommon.ProposeTxResult result, @NonNull UnsignedLong blockIndex) {
         super(result.toString());
         this.result = result;
+        this.blockIndex = blockIndex;
     }
 
     /**
@@ -50,8 +55,8 @@ public final class InvalidTransactionException extends MobileCoinException {
      *
      * @param message the {@link Exception} message
      * @deprecated Deprecated as of 1.2.2. Please use
-     * {@link InvalidTransactionException#InvalidTransactionException(ConsensusCommon.ProposeTxResult)}.
-     * @see InvalidTransactionException#InvalidTransactionException(ConsensusCommon.ProposeTxResult).
+     * {@link InvalidTransactionException#InvalidTransactionException(ConsensusCommon.ProposeTxResult, UnsignedLong)}.
+     * @see InvalidTransactionException#InvalidTransactionException(ConsensusCommon.ProposeTxResult, UnsignedLong) .
      * @see ConsensusCommon.ProposeTxResult
      * @since 1.0.0
      */
@@ -59,6 +64,7 @@ public final class InvalidTransactionException extends MobileCoinException {
     public InvalidTransactionException(@Nullable String message) {
         super(message);
         this.result = null;
+        this.blockIndex = null;
     }
 
     /**
@@ -71,6 +77,18 @@ public final class InvalidTransactionException extends MobileCoinException {
     @Nullable
     public ConsensusCommon.ProposeTxResult getResult() {
         return this.result;
+    }
+
+    /**
+     * Returns the consensus blockIndex.
+     *
+     * @return blockIndex at the time of consensus that returned the error
+     * @see ConsensusCommon.ProposeTxResult
+     * @since 1.2.2
+     */
+    @Nullable
+    public UnsignedLong getBlockIndex() {
+        return this.blockIndex;
     }
 
 }


### PR DESCRIPTION
### Motivation

The Swift SDK ensures that the returning block index is [never below 0](https://github.com/mobilecoinofficial/MobileCoin-Swift/blob/master/Sources/Transaction/TransactionSubmitter.swift#L38). This does the same for Android.

### In this PR
* If `blockIndex` is 0, don't subtract 1 from it, making it negative.
