### PR TITLE
Add rng seed

### DIFF
--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TxOutMemoIntegrationTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TxOutMemoIntegrationTest.java
@@ -102,7 +102,7 @@ public class TxOutMemoIntegrationTest {
         .unmaskAmount(senderAccountKey.getViewKey(), realTxOut.getPublicKey()).getValue();
     BigInteger changeValue = realTxOutValue.subtract(fee.getValue())
         .subtract(sentTxOutValue);
-    transactionBuilder.addChangeOutput(changeValue, senderAccountKey, null);
+    transactionBuilder.addChangeOutput(changeValue, senderAccountKey, null, null);
     Transaction transaction = transactionBuilder.build();
 
     List<MobileCoinAPI.TxOut> outputsList = transaction.toProtoBufObject().getPrefix()
@@ -162,7 +162,7 @@ public class TxOutMemoIntegrationTest {
     BigInteger realTxOutValue = realTxOut.getMaskedAmount()
         .unmaskAmount(senderAccountKey.getViewKey(), realTxOut.getPublicKey()).getValue();
     BigInteger changeValue = realTxOutValue.subtract(fee.getValue()).subtract(txValue);
-    transactionBuilder.addChangeOutput(changeValue, senderAccountKey, null);
+    transactionBuilder.addChangeOutput(changeValue, senderAccountKey, null, null);
     Transaction transaction = transactionBuilder.build();
 
     List<MobileCoinAPI.TxOut> outputsList = transaction.toProtoBufObject().getPrefix()
@@ -224,7 +224,7 @@ public class TxOutMemoIntegrationTest {
         .unmaskAmount(senderAccountKey.getViewKey(), realTxOut.getPublicKey()).getValue();
     BigInteger changeValue = realTxOutValue.subtract(fee.getValue())
         .subtract(sentTxOutValue);
-    transactionBuilder.addChangeOutput(changeValue, senderAccountKey, null);
+    transactionBuilder.addChangeOutput(changeValue, senderAccountKey, null, null);
     Transaction transaction = transactionBuilder.build();
 
     List<MobileCoinAPI.TxOut> outputsList = transaction.toProtoBufObject().getPrefix()
@@ -284,7 +284,7 @@ public class TxOutMemoIntegrationTest {
             .unmaskAmount(senderAccountKey.getViewKey(), realTxOut.getPublicKey()).getValue();
     BigInteger changeValue = realTxOutValue.subtract(fee.getValue())
             .subtract(sentTxOutValue);
-    transactionBuilder.addChangeOutput(changeValue, senderAccountKey, null);
+    transactionBuilder.addChangeOutput(changeValue, senderAccountKey, null, null);
     Transaction transaction = transactionBuilder.build();
 
     List<MobileCoinAPI.TxOut> outputsList = transaction.toProtoBufObject().getPrefix()

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TxOutMemoIntegrationTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TxOutMemoIntegrationTest.java
@@ -97,7 +97,7 @@ public class TxOutMemoIntegrationTest {
     transactionBuilder.setTombstoneBlockIndex(UnsignedLong.valueOf(2000));
     BigInteger sentTxOutValue = BigInteger.ONE;
 
-    transactionBuilder.addOutput(sentTxOutValue, recipientAccountKey.getPublicAddress(), null);
+    transactionBuilder.addOutput(sentTxOutValue, recipientAccountKey.getPublicAddress(), null, null);
     BigInteger realTxOutValue = realTxOut.getMaskedAmount()
         .unmaskAmount(senderAccountKey.getViewKey(), realTxOut.getPublicKey()).getValue();
     BigInteger changeValue = realTxOutValue.subtract(fee.getValue())
@@ -158,7 +158,7 @@ public class TxOutMemoIntegrationTest {
     transactionBuilder.setTombstoneBlockIndex(UnsignedLong.valueOf(2000));
     BigInteger txValue = BigInteger.ONE;
 
-    transactionBuilder.addOutput(txValue, recipientAccountKey.getPublicAddress(), null);
+    transactionBuilder.addOutput(txValue, recipientAccountKey.getPublicAddress(), null, null);
     BigInteger realTxOutValue = realTxOut.getMaskedAmount()
         .unmaskAmount(senderAccountKey.getViewKey(), realTxOut.getPublicKey()).getValue();
     BigInteger changeValue = realTxOutValue.subtract(fee.getValue()).subtract(txValue);
@@ -219,7 +219,7 @@ public class TxOutMemoIntegrationTest {
     transactionBuilder.setTombstoneBlockIndex(UnsignedLong.valueOf(2000));
     BigInteger sentTxOutValue = BigInteger.ONE;
 
-    transactionBuilder.addOutput(sentTxOutValue, recipientAccountKey.getPublicAddress(), null);
+    transactionBuilder.addOutput(sentTxOutValue, recipientAccountKey.getPublicAddress(), null, null);
     BigInteger realTxOutValue = realTxOut.getMaskedAmount()
         .unmaskAmount(senderAccountKey.getViewKey(), realTxOut.getPublicKey()).getValue();
     BigInteger changeValue = realTxOutValue.subtract(fee.getValue())
@@ -279,7 +279,7 @@ public class TxOutMemoIntegrationTest {
     transactionBuilder.setTombstoneBlockIndex(UnsignedLong.valueOf(2000));
     BigInteger sentTxOutValue = BigInteger.ONE;
 
-    transactionBuilder.addOutput(sentTxOutValue, recipientAccountKey.getPublicAddress(), null);
+    transactionBuilder.addOutput(sentTxOutValue, recipientAccountKey.getPublicAddress(), null, null);
     BigInteger realTxOutValue = realTxOut.getMaskedAmount()
             .unmaskAmount(senderAccountKey.getViewKey(), realTxOut.getPublicKey()).getValue();
     BigInteger changeValue = realTxOutValue.subtract(fee.getValue())

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -565,7 +565,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
             changeTxOutContext = txBuilder.addOutput(change, accountKey.getPublicAddress(), rngSeed, null);
         }
         else {
-            changeTxOutContext = txBuilder.addChangeOutput(change, accountKey, null);
+            changeTxOutContext = txBuilder.addChangeOutput(change, accountKey, rngSeed, null);
         }
 
         Transaction transaction = txBuilder.build();

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
@@ -75,6 +75,28 @@ public interface MobileCoinTransactionClient {
           InvalidFogResponse, AttestationException, NetworkException,
           TransactionBuilderException, FogReportException, FogSyncException;
 
+  /**
+   * Prepares a {@link PendingTransaction} to be executed.
+   *
+   * @param recipient {@link PublicAddress} of the recipient
+   * @param amount    transaction amount
+   * @param fee       transaction fee (see {@link MobileCoinClient#estimateTotalFee})
+   * @param txOutMemoBuilder
+   * @param rngSeed   seed used for generating public key
+   * @return {@link PendingTransaction} which encapsulates the {@link Transaction} and {@link
+   * Receipt} objects
+   */
+  @NonNull
+  PendingTransaction prepareTransaction(
+      @NonNull final PublicAddress recipient,
+      @NonNull final Amount amount,
+      @NonNull final Amount fee,
+      @NonNull TxOutMemoBuilder txOutMemoBuilder,
+      byte[] rngSeed
+  ) throws InsufficientFundsException, FragmentedAccountException, FeeRejectedException,
+          InvalidFogResponse, AttestationException, NetworkException,
+          TransactionBuilderException, FogReportException, FogSyncException;
+
 
   /**
    * Submits a {@link Transaction} to the consensus service.

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TransactionBuilder.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TransactionBuilder.java
@@ -89,18 +89,18 @@ final class TransactionBuilder extends Native {
     TxOutContext addChangeOutput(
         @NonNull BigInteger value,
         @NonNull AccountKey accountKey,
+        @NonNull byte[] rngSeed,
         @Nullable byte[] confirmationNumberOut
     ) throws TransactionBuilderException {
         Logger.i(TAG, "Adding transaction output");
-        byte[] confirmationOut = new byte[Receipt.CONFIRMATION_NUMBER_LENGTH];
         try {
-            long rustObj = add_change_output(value, accountKey, confirmationOut);
+            long rustObj = add_change_output(value, accountKey, rngSeed);
             if (confirmationNumberOut != null) {
                 if (confirmationNumberOut.length < Receipt.CONFIRMATION_NUMBER_LENGTH) {
                     throw new IllegalArgumentException("ConfirmationNumber buffer is too small");
                 }
-                System.arraycopy(confirmationOut, 0, confirmationNumberOut, 0,
-                    confirmationOut.length);
+                System.arraycopy(rngSeed, 0, confirmationNumberOut, 0,
+                    rngSeed.length);
             }
             return TxOutContext.fromJNI(rustObj);
         } catch (Exception exception) {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TransactionBuilder.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TransactionBuilder.java
@@ -62,21 +62,21 @@ final class TransactionBuilder extends Native {
     TxOutContext addOutput(
             @NonNull BigInteger value,
             @NonNull PublicAddress recipient,
+            @NonNull byte[] rngSeed,
             @Nullable byte[] confirmationNumberOut
     ) throws TransactionBuilderException {
         Logger.i(TAG, "Adding transaction output");
-        byte[] confirmationOut = new byte[Receipt.CONFIRMATION_NUMBER_LENGTH];
         try {
             long rustObj = add_output(value,
                     recipient,
-                    confirmationOut
+                    rngSeed
             );
             if (confirmationNumberOut != null) {
                 if (confirmationNumberOut.length < Receipt.CONFIRMATION_NUMBER_LENGTH) {
                     throw new IllegalArgumentException("ConfirmationNumber buffer is too small");
                 }
-                System.arraycopy(confirmationOut, 0, confirmationNumberOut, 0,
-                        confirmationOut.length);
+                System.arraycopy(rngSeed, 0, confirmationNumberOut, 0,
+                        rngSeed.length);
             }
             return TxOutContext.fromJNI(rustObj);
         } catch (Exception exception) {


### PR DESCRIPTION
### Motivation

Ensure idempotence by providing the random number generator to guarantee the same generated public key, which can only exist on the block chain at most one time.

### In this PR
* Adds a new constructor that includes the `rngSeed` param and passes it along to the rust bridge.

### Future Work
* Test that it works
