### PR TITLE
Fixing Missing JNI Dependency

### DIFF
--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '1.2.1'
+version '1.2.2-pre3'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()
@@ -20,6 +20,14 @@ publishing {
                 def dependenciesNode = asNode().appendNode('dependencies')
                 configurations.grpcImplementation.allDependencies.each {
                     // Ensure dependencies such as fileTree are not included in the pom.
+                    if (it.name != 'unspecified') {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+                configurations.implementation.allDependencies.each {
                     if (it.name != 'unspecified') {
                         def dependencyNode = dependenciesNode.appendNode('dependency')
                         dependencyNode.appendNode('groupId', it.group)


### PR DESCRIPTION
### Motivation

This PR is needed to resolve an issue in version 1.2.1 where the JNI libraries are not included as a dependency.

### In this PR
* Update publish task to add JNI libs to dependencies
