### PR TITLE
Release 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,27 @@ some issues caused by `OwnedTxOut`s being updated after being fetched from the p
 - Fixed default HttpRequester authentication
 - Fixed a dependency issue introduced by some project structure changes
 
+### Upgrading
+
+No code changes are *required* to upgrade from 1.2.1 to 1.2.2
+
+- To easily handle various types of transaction failure differently, code such as the following
+can be used: `switch(invalidTransactionException.getResult())`
+- To obtain the Consensus block index at the time of `Transaction` submission, check the return
+value of `MobileCoinTransactionClient.submitTransaction`
+
 ## [1.2.1] - 2022-06-07
 ### Added
 - Added Amount.ofMOB(BigInteger value) to create an Amount with MOB token ID
 
 ### Changed
 - Updated bindings to version 1.2.1
+
+### Upgrading
+
+No code changes are *required* to upgrade from 1.2.0 to 1.2.1
+
+- Calls to `new Amount(value, TokenId.MOB)` may be replaced with `Amount.ofMOB(value)`.
 
 ## [1.2.0] - 2022-06-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2022-07-21
+### Added
+- Added a `ProposeTxResult` field to `InvalidTransactionException`. This field indicates why the
+`Transaction` was not accepted.
+- `MobileCoinTransactionClient.submitTransaction` now returns Consensus block count at submission time.
+
+### Changed
+- Updated bindings to version 1.2.2
+
+### Fixes
+- `OwnedTxOut`s returned through the public API are copied from internal `OwnedTxOut`s. This fixes
+some issues caused by `OwnedTxOut`s being updated after being fetched from the public API.
+- Fixed default HttpRequester authentication
+- Fixed a dependency issue introduced by some project structure changes
+
 ## [1.2.1] - 2022-06-07
 ### Added
 - Added Amount.ofMOB(BigInteger value) to create an Amount with MOB token ID

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,21 @@ some issues caused by `OwnedTxOut`s being updated after being fetched from the p
 - FogSyncException will be thrown if Fog View and Ledger are out of sync with each other or Consensus.
   This signifies that balances may temporarily be out of date or incorrect.
 
+### Upgrading
+- The constructor for `MobileCoinClient` now requires one additional parameter, a `TransportProtocol`
+This can either be `TransportProtocol.forGRPC()` or `TransportProtocol.forHTTP(Requester)`.
+- Some methods that interact with network services now throw a `FogSyncException`. This signifies
+that the information gathered from the network may be temporarily out of date.
+- With support for multiple token types, various account and transaction related methods have been
+deprecated. Many of these deprecated methods have simply been parameterized for a `TokenId`. Refer
+to the Javadoc of deprecated methods for instructions on what to use instead. Until they are removed,
+deprecated API methods will continue to function identically to how they did in 1.1.
+- For sending transactions, a `TxOutMemoBuilder` will be required to create `TxOutMemo`s. These can
+be used to reconstruct
+[Recoverable Transaction History (RTH)](https://github.com/mobilecoinfoundation/mcips/blob/main/text/0004-recoverable-transaction-history.md).
+This will be required on network version 1.2.0. `TxOutMemoBuilder.createSenderAndDestinationRTHMemoBuilder()`
+can be used to satisfy this requirement and is reverse compatible with network version 1.1.
+
 ## [1.2.0-pre0] - 2021-09-15
 ### Added
 - Network Robustness. Host applications now have the ability to choose which transport protocols

--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '1.2.2-pre3'
+version '1.2.2'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '1.2.2-pre4'
+version '1.2.2'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '1.2.2'
+version '1.2.2-pre4'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AccountActivity.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AccountActivity.java
@@ -48,6 +48,9 @@ public final class AccountActivity {
     /**
      * @return all account MOB TxOuts at the particular block count, see
      * {@link AccountActivity#getBlockCount}
+     *
+     * @deprecated Deprecated as of 1.2.0. Please use {@link AccountActivity#getAllTokenTxOuts()}.
+     * @see AccountActivity#getAllTokenTxOuts()
      * @since 1.0.0
      */
     @Deprecated

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AccountSnapshot.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AccountSnapshot.java
@@ -63,6 +63,11 @@ public final class AccountSnapshot {
 
     /**
      * Computes the account's balance as it was at the snapshot's block index
+     * 
+     * @deprecated Deprecated as of 1.2.0. Please use {@link AccountSnapshot#getBalance(TokenId)} or
+     * {@link AccountSnapshot#getBalances()}
+     * @see AccountSnapshot#getBalance(TokenId)
+     * @see AccountSnapshot#getBalances()
      */
     @NonNull
     @Deprecated
@@ -215,6 +220,9 @@ public final class AccountSnapshot {
      *
      * @param minimumTxFee minimum transaction fee, see
      * {@link MobileCoinClient#getOrFetchMinimumTxFee}
+     *                     
+     * @deprecated Deprecated as of 1.2.0. Please use {@link AccountSnapshot#getTransferableAmount(Amount)}.
+     * @see AccountSnapshot#getTransferableAmount(Amount)
      */
     @Deprecated
     @NonNull
@@ -255,6 +263,8 @@ public final class AccountSnapshot {
      * @param amountPicoMOB       an amount value in picoMob
      * @param minimumTxFee minimum transaction fee, see
      *                     {@link MobileCoinClient#getOrFetchMinimumTxFee}
+     * @deprecated Deprecated as of 1.2.0. Please use {@link AccountSnapshot#estimateTotalFee(Amount, Amount)}.
+     * @see AccountSnapshot#estimateTotalFee(Amount, Amount)
      */
     @Deprecated
     @NonNull
@@ -306,6 +316,9 @@ public final class AccountSnapshot {
      * @param feePicoMOB    transaction fee (see {@link MobileCoinClient#estimateTotalFee})
      * @return {@link PendingTransaction} which encapsulates the {@link Transaction} and {@link
      * Receipt} objects
+     * 
+     * @deprecated Deprecated as of 1.2.0. Please use {@link AccountSnapshot#prepareTransaction(PublicAddress, Amount, Amount, TxOutMemoBuilder)}.
+     * @see AccountSnapshot#prepareTransaction(PublicAddress, Amount, Amount, TxOutMemoBuilder) 
      */
     @Deprecated
     @NonNull

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Balance.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Balance.java
@@ -25,6 +25,8 @@ final public class Balance {
 
     /**
      * Returns the balance amount in pico MOBs
+     * @deprecated Deprecated as of 1.2.0. Please use {@link Balance#getValue()}.
+     * @see Balance#getValue()
      */
     @NonNull
     @Deprecated

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinAccountClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinAccountClient.java
@@ -54,6 +54,11 @@ public interface MobileCoinAccountClient {
 
   /**
    * Retrieves {@code AccountKey}'s MOB balance in picoMOB.
+   *
+   * @deprecated Deprecated as of 1.2.0. Please use {@link MobileCoinAccountClient#getBalance(TokenId)}
+   * or {@link MobileCoinAccountClient#getBalances()}.
+   * @see MobileCoinAccountClient#getBalance(TokenId)
+   * @see MobileCoinAccountClient#getBalances()
    */
   @NonNull
   @Deprecated
@@ -74,6 +79,9 @@ public interface MobileCoinAccountClient {
   /**
    * Returns whether the defragmentation is required on the active account in order to send the
    * specified amount of picoMOB
+   *
+   * @deprecated Deprecated as of 1.2.0. Please use {@link MobileCoinAccountClient#requiresDefragmentation(Amount)}
+   * @see MobileCoinAccountClient#requiresDefragmentation(Amount)
    */
   @Deprecated
   boolean requiresDefragmentation(@NonNull BigInteger amountPicoMOB)
@@ -97,7 +105,10 @@ public interface MobileCoinAccountClient {
    * <p>If the account is too fragmented, it might be necessary to defragment the account more than
    * once. However, wallet fragmentation is a rare occurrence since there is an internal mechanism
    * to defragment the account during other operations.
-   *  @param delegate monitors and controls the defragmentation process
+   * @param delegate monitors and controls the defragmentation process
+   *
+   * @deprecated Deprecated as of 1.2.0. Please use {@link MobileCoinAccountClient#defragmentAccount(Amount, DefragmentationDelegate, boolean)}.
+   * @see MobileCoinAccountClient#defragmentAccount(Amount, DefragmentationDelegate, boolean)
    */
   @Deprecated
   void defragmentAccount(

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
@@ -23,6 +23,9 @@ public interface MobileCoinTransactionClient {
 
   /**
    * Calculate the total transferable amount of picoMOB excluding all the required fees for such transfer.
+   *
+   * @deprecated Deprecated as of 1.2.0. Please use {@link MobileCoinTransactionClient#getTransferableAmount(TokenId)}
+   * @see MobileCoinTransactionClient#getTransferableAmount(TokenId)
    */
   @Deprecated
   @NonNull
@@ -44,6 +47,9 @@ public interface MobileCoinTransactionClient {
    * @param feePicoMOB       transaction fee (see {@link MobileCoinClient#estimateTotalFee})
    * @return {@link PendingTransaction} which encapsulates the {@link Transaction} and {@link
    * Receipt} objects
+   *
+   * @deprecated Deprecated as of 1.2.0. Please use {@link MobileCoinTransactionClient#prepareTransaction(PublicAddress, Amount, Amount, TxOutMemoBuilder)}
+   * @see MobileCoinTransactionClient#prepareTransaction(PublicAddress, Amount, Amount, TxOutMemoBuilder)
    */
   @Deprecated
   @NonNull
@@ -117,6 +123,9 @@ public interface MobileCoinTransactionClient {
    * defragmented in order to send the specified amount. See {@link MobileCoinAccountClient#defragmentAccount}.
    *
    * @param amountPicoMOB amount to send in picoMOB
+   *
+   * @deprecated Deprecated as of 1.2.0. Please use {@link MobileCoinTransactionClient#estimateTotalFee(Amount)}
+   * @see MobileCoinTransactionClient#estimateTotalFee(Amount)
    */
   @Deprecated
   @NonNull
@@ -139,6 +148,9 @@ public interface MobileCoinTransactionClient {
 
   /**
    * Fetches or returns the cached minimum MOB transaction fee in picoMOB
+   *
+   * @deprecated Deprecated as of 1.2.0. Please use {@link MobileCoinTransactionClient#getOrFetchMinimumTxFee(TokenId)}
+   * @see MobileCoinTransactionClient#getOrFetchMinimumTxFee(TokenId)
    */
   @Deprecated
   @NonNull

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
@@ -147,6 +147,9 @@ public class OwnedTxOut implements Parcelable {
 
     /**
      * @return The value of this TxOut
+     *
+     * @deprecated Deprecated as of 1.2.0. Please use {@link OwnedTxOut#getAmount()}.
+     * @see OwnedTxOut#getAmount()
      */
     @Deprecated
     @NonNull
@@ -156,6 +159,9 @@ public class OwnedTxOut implements Parcelable {
 
     /**
      * @return The token ID of this TxOut
+     *
+     * @deprecated Deprecated as of 1.2.0. Please use {@link OwnedTxOut#getAmount()}.
+     * @see OwnedTxOut#getAmount()
      */
     @Deprecated
     @NonNull

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Receipt.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Receipt.java
@@ -116,6 +116,9 @@ public final class Receipt {
 
     /**
      * @return {@link BigInteger} decoded receipt value
+     *
+     * @deprecated Deprecated as of 1.2.0. Please use {@link Receipt#getAmountData(AccountKey)}
+     * @see Receipt#getAmountData(AccountKey)
      */
     @NonNull
     @Deprecated


### PR DESCRIPTION
### Motivation

To aid in the integration of newer versions of the SDK, an **Upgrading** section has been added to the changelog. This PR also bumps the version number to 1.2.2 for the 1.2.2 SDK release.

### In this PR
* Changelog integration instructions
* Javadoc for all deprecated methods providing alternative methods
