### PR TITLE
Minor Release 1.2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2.1] - 2022-07-21
+### Added
+- Added `AccountActivity.getAllTokenTxOuts(TokenId)`
+
+### Changed
+- Changed visibility of `OwnedTxOut.getAmount()` to public
+
+### Upgrading
+
+No code changes are *required* to upgrade from 1.2.2 to 1.2.2.1
+
 ## [1.2.2] - 2022-07-21
 ### Added
 - Added a `ProposeTxResult` field to `InvalidTransactionException`. This field indicates why the

--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '1.2.2'
+version '1.2.2.1'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AccountActivity.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AccountActivity.java
@@ -64,8 +64,25 @@ public final class AccountActivity {
     }
 
     /**
+     * @return all account TxOuts for the specified TokenId at the particular block count
+     * @param tokenId the {@link TokenId} to filter by
+     * @see AccountActivity#getBlockCount
+     * @since 1.2.2.1
+     */
+    @NonNull
+    public Set<OwnedTxOut> getAllTokenTxOuts(TokenId tokenId) {
+        Logger.i(TAG, "GetAllTxOuts", null,
+                "txOuts count:", txOuts.size());
+        return txOuts.stream()
+                .filter(otxo -> tokenId.equals(otxo.getAmount().getTokenId()))
+                .collect(Collectors.toSet());
+    }
+
+    /**
      * @return all account TxOuts at the particular block count, see
      * {@link AccountActivity#getBlockCount}
+     *
+     * @since 1.2.0
      */
     @NonNull
     public Set<OwnedTxOut> getAllTokenTxOuts() {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
@@ -172,7 +172,8 @@ public class OwnedTxOut implements Parcelable {
     /**
      * @return The amount of this TxOut
      */
-    @NonNull Amount getAmount() {
+    @NonNull
+    public Amount getAmount() {
         return amount;
     }
 


### PR DESCRIPTION
### Motivation

This version includes a few minor changes to make SDK version 1.2.0+ integration easier for clients

### In this PR
* Add method in AccountActivity to filter OwnedTxOuts by TokenId
* Change visibility of OwnedTxOut.getAmount() to public
* Increment version number from 1.2.2 to 1.2.2.1