### PR TITLE
Fix StatusRuntimeException escaping

### DIFF
--- a/android-sdk/src/grpc/java/com/mobilecoin/lib/network/services/grpc/GRPCFogKeyImageService.java
+++ b/android-sdk/src/grpc/java/com/mobilecoin/lib/network/services/grpc/GRPCFogKeyImageService.java
@@ -44,7 +44,11 @@ public class GRPCFogKeyImageService
     }
 
     @Override
-    public Attest.Message checkKeyImages(Attest.Message request) {
-        return getApiBlockingStub().checkKeyImages(request);
+    public Attest.Message checkKeyImages(Attest.Message request) throws NetworkException {
+        try {
+            return getApiBlockingStub().checkKeyImages(request);
+        } catch (StatusRuntimeException e) {
+            throw new NetworkException(new NetworkResult(new GRPCStatusResponse(e.getStatus())), e);
+        }
     }
 }


### PR DESCRIPTION
### Motivation

Signal reported a crash caused by an uncaught StatusRuntimeException being thrown from GRPCFogKeyImageService.checkKeyImages. This method is supposed to catch the StatusRuntimeException and pass it up as a NetworkException

### In this PR
* Fix GRPCFogKeyImageService.checkKeyImages not throwing NetworkException

### Future Work
* Minor bug-fix release for this change
