### PR TITLE
Add getTransactionStatusQuick method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,10 @@ jobs:
           name: Provide Alpha root entropies
           command: echo $DEV_NET_TEST_ENTROPIES > android-sdk/src/androidTest/res/raw/dev_net_root_entropies
 
-      - run: make setup
-      - run: make build
       - run:
           name: make tests
           command: make tests
-          no_output_timeout: 20m
+          no_output_timeout: 30m
 
       - store_artifacts:
           path: android-sdk/build/reports

--- a/.github/workflows/android-sdk-dispatch.yml
+++ b/.github/workflows/android-sdk-dispatch.yml
@@ -1,0 +1,20 @@
+name: Publish Android SDK 
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_publish:
+    runs-on: [self-hosted, Linux, small]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build and Publish the SDK
+        env:
+          MAVEN_USER: ${{ secrets.MAVEN_USER }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+        working-directory: ./
+        run: |
+          make publish
+

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -34,6 +34,7 @@ protobuf {
 }
 
 android {
+    buildToolsVersion "30.0.3"
     compileSdkVersion build_versions.compile_sdk
     useLibrary 'android.test.runner'
     useLibrary 'android.test.base'

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -648,7 +648,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
     @NonNull
     public Transaction.Status getTransactionStatusQuick(@NonNull Transaction transaction)
             throws NetworkException {
-        Logger.i(TAG, "GetTransactionStatus call");
+        Logger.i(TAG, "GetTransactionStatusQuick call");
         Set<RistrettoPublic> outputPublicKeys = transaction.getOutputPublicKeys();
         Ledger.TxOutResponse response = getUntrustedClient().fetchTxOuts(outputPublicKeys);
         List<Ledger.TxOutResult> results = response.getResultsList();

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ USER root
 ENV SDK_URL="https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip" \
     ANDROID_HOME="/usr/local/android-sdk" \
     ANDROID_VERSION=30 \
-    ANDROID_BUILD_TOOLS_VERSION=30.0.2 \
+    ANDROID_BUILD_TOOLS_VERSION=30.0.3 \
     PATH="$PATH":/usr/local/bin:/usr/local/google-cloud-sdk/bin \
     GCLOUD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-294.0.0-linux-x86_64.tar.gz"
 
@@ -17,7 +17,7 @@ RUN mkdir "$ANDROID_HOME" .android \
     && rm sdk.zip \
     && mkdir "$ANDROID_HOME/licenses" || true \
     && echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_HOME/licenses/android-sdk-license" \
-    && echo "y" | $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager --licenses
+    && yes | $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager --licenses
 
 # Install Android Build Tool and Libraries
 RUN $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager --update

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Oct 13 08:45:10 PDT 2020
 distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip

--- a/testApp/build.gradle
+++ b/testApp/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.mobilecoin.lib.app"

--- a/testApp/src/main/AndroidManifest.xml
+++ b/testApp/src/main/AndroidManifest.xml
@@ -5,5 +5,6 @@
         android:allowBackup="true"
         android:label="testApp"
         android:supportsRtl="true"
+        android:exported="true"
          />
 </manifest>


### PR DESCRIPTION
### In this PR

* Added the ability to publish from GA
* Added a quick version of the transaction status check
* Removed duplicated runs in CircleCi config 
  - Tests depend on `build`, and `build` depends on `setup` no need to re-run them separately