### PR TITLE
Changing order of prepareTransaction RNG calls

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -128,6 +128,6 @@ dependencies {
     androidTestImplementation deps.testing.rules
     androidTestImplementation deps.testing.espresso_core
     androidTestImplementation deps.testing.support_rules
-    androidTestImplementation deps.testing.okhttp
+    androidTestImplementation deps.testing.okhttp3
 
 }

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
@@ -6,7 +6,7 @@ import androidx.annotation.VisibleForTesting;
 
 @VisibleForTesting
 public class Environment {
-    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.MOBILE_DEV;
+    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.TEST_NET;
 
     static public TestFogConfig getTestFogConfig() {
         return TestFogConfig.getFogConfig(CURRENT_TEST_ENV);

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TransactionBuilderTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TransactionBuilderTest.java
@@ -1,8 +1,6 @@
 package com.mobilecoin.lib;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -11,7 +9,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.math.BigInteger;
-import java.util.Arrays;
 
 @RunWith(AndroidJUnit4.class)
 public class TransactionBuilderTest {
@@ -39,11 +36,8 @@ public class TransactionBuilderTest {
                 TxOutMemoBuilder.createSenderAndDestinationRTHMemoBuilder(client.getAccountKey()),
                 rng
         ).getTransaction();
-        assertEquals(transaction1.getTombstoneBlockIndex(), transaction2.getTombstoneBlockIndex());
-        assertEquals(transaction1.getFee(), transaction2.getFee());
-        assertEquals(transaction1.getKeyImages(), transaction2.getKeyImages());
+
         assertEquals(transaction1.getOutputPublicKeys(), transaction2.getOutputPublicKeys());
-        assertArrayEquals(transaction1.toByteArray(), transaction2.toByteArray());
 
         final AccountSnapshot snapshot = client.getAccountSnapshot();
         rng.setWordPos(BigInteger.ZERO);
@@ -62,11 +56,8 @@ public class TransactionBuilderTest {
                 TxOutMemoBuilder.createSenderAndDestinationRTHMemoBuilder(client.getAccountKey()),
                 rng
         ).getTransaction();
-        assertEquals(transaction1.getTombstoneBlockIndex(), transaction2.getTombstoneBlockIndex());
-        assertEquals(transaction1.getFee(), transaction2.getFee());
-        assertEquals(transaction1.getKeyImages(), transaction2.getKeyImages());
+
         assertEquals(transaction1.getOutputPublicKeys(), transaction2.getOutputPublicKeys());
-        assertArrayEquals(transaction1.toByteArray(), transaction2.toByteArray());
 
         // Rebuild transaction2 WITHOUT resetting rng word pos
         transaction2 = snapshot.prepareTransaction(
@@ -77,13 +68,7 @@ public class TransactionBuilderTest {
                 rng
         ).getTransaction();
 
-        // Should still be same with different RNG state
-        assertEquals(transaction1.getTombstoneBlockIndex(), transaction2.getTombstoneBlockIndex());
-        assertEquals(transaction1.getFee(), transaction2.getFee());
-        assertEquals(transaction1.getKeyImages(), transaction2.getKeyImages());
-        // These should be different if RNG with different state used
         assertNotEquals(transaction1.getOutputPublicKeys(), transaction2.getOutputPublicKeys());
-        assertFalse(Arrays.equals(transaction1.toByteArray(), transaction2.toByteArray()));
 
     }
 

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TransactionBuilderTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TransactionBuilderTest.java
@@ -2,8 +2,11 @@ package com.mobilecoin.lib;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.mobilecoin.lib.util.Hex;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,8 +18,8 @@ public class TransactionBuilderTest {
 
     @Test
     public void testReproducibleTransactions() throws Exception {
-        ChaCha20Rng rng = ChaCha20Rng.withRandomSeed();
-        MobileCoinClient client = MobileCoinClientBuilder.newBuilder().build();
+        final ChaCha20Rng rng = ChaCha20Rng.fromSeed(new byte[] {103, 111, 116, 111, 32, 104, 116, 116, 112, 115, 58, 47, 47, 98, 117, 121, 46, 109, 111, 98, 105, 108, 101, 99, 111, 105, 110, 46, 99, 111, 109, 0});
+        final MobileCoinClient client = MobileCoinClientBuilder.newBuilder().build();
         final Amount amountToSend = Amount.ofMOB(BigInteger.valueOf(52398457942L));
         final Amount fee = client.estimateTotalFee(amountToSend);
         final PublicAddress recipient = TestKeysManager.getNextAccountKey().getPublicAddress();
@@ -69,6 +72,41 @@ public class TransactionBuilderTest {
         ).getTransaction();
 
         assertNotEquals(transaction1.getOutputPublicKeys(), transaction2.getOutputPublicKeys());
+
+    }
+
+    @Test
+    public void testPredictableOutputPublicKey() throws Exception {
+        // Given RNG seed and recipient public address
+        final ChaCha20Rng rng = ChaCha20Rng.fromSeed(Hex.toByteArray("676f746f2068747470733a2f2f6275792e6d6f62696c65636f696e2e636f6d00"));
+        final PublicAddress recipient = PublicAddress.fromBytes(Hex.toByteArray("0a220a2048d9e6aa836d7aa57f7a9da9709603d8f5071faff4908c86ed829e68c0129f6312220a207ee52b7741a8b9f3701ab716fa361483b03ddcaeecb64ba64355a3411c87d43d"));
+        // TxOut public key that should appear
+        final RistrettoPublic expectedTxOutPublicKey = RistrettoPublic.fromBytes(Hex.toByteArray("d47d4f6525cee846a47106e92de3e63e5b3cb677b8ae4df7efd667e2bad15719"));
+
+        final MobileCoinClient client = MobileCoinClientBuilder.newBuilder().build();
+        final Amount amountToSend = Amount.ofMOB(BigInteger.valueOf(52398457942L));
+        final Amount fee = client.estimateTotalFee(amountToSend);
+        Transaction client1Transaction = client.prepareTransaction(
+                recipient,
+                amountToSend,
+                fee,
+                TxOutMemoBuilder.createSenderAndDestinationRTHMemoBuilder(client.getAccountKey()),
+                rng
+        ).getTransaction();
+
+        rng.setWordPos(BigInteger.ZERO);
+
+        MobileCoinClient client2 = MobileCoinClientBuilder.newBuilder().build();
+        Transaction client2Transaction = client2.prepareTransaction(
+                recipient,
+                amountToSend,
+                fee,
+                TxOutMemoBuilder.createSenderAndDestinationRTHMemoBuilder(client2.getAccountKey()),
+                rng
+        ).getTransaction();
+
+        assertTrue(client1Transaction.getOutputPublicKeys().contains(expectedTxOutPublicKey));
+        assertTrue(client2Transaction.getOutputPublicKeys().contains(expectedTxOutPublicKey));
 
     }
 

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/util/SimpleRequester.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/util/SimpleRequester.java
@@ -5,21 +5,20 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 
 import com.mobilecoin.lib.network.services.http.Requester.Requester;
-import com.squareup.okhttp.Authenticator;
-import com.squareup.okhttp.Credentials;
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
-import com.squareup.okhttp.Response;
 
 import java.io.IOException;
-import java.net.Proxy;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import okhttp3.Credentials;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 /**
  * Simple Requester is intended to be used for the integration tests
@@ -27,21 +26,11 @@ import java.util.Set;
 public class SimpleRequester implements Requester {
 
     private final OkHttpClient httpClient;
+    private final String basicAuthHeader;
 
     public SimpleRequester(String username, String password) {
         httpClient = new OkHttpClient();
-        final String credential = Credentials.basic(username, password);
-        httpClient.setAuthenticator(new Authenticator() {
-            @Override
-            public Request authenticate(Proxy proxy, Response response) throws IOException {
-                return response.request().newBuilder().header("Authorization", credential).build();
-            }
-
-            @Override
-            public Request authenticateProxy(Proxy proxy, Response response) throws IOException {
-                return response.request().newBuilder().header("Proxy-Authorization", credential).build();
-            }
-        });
+        basicAuthHeader = Credentials.basic(username, password);
     }
 
     @NonNull
@@ -58,6 +47,7 @@ public class SimpleRequester implements Requester {
                 body
         );
 
+        headers.put("Authorization", basicAuthHeader);
         Request request = new Request.Builder()
                 .method(httpMethod, requestBody)
                 .headers(Headers.of(headers))

--- a/android-sdk/src/grpc/java/com/mobilecoin/lib/network/grpc/AuthInterceptor.java
+++ b/android-sdk/src/grpc/java/com/mobilecoin/lib/network/grpc/AuthInterceptor.java
@@ -4,8 +4,6 @@ package com.mobilecoin.lib.network.grpc;
 
 import androidx.annotation.NonNull;
 
-import com.squareup.okhttp.Credentials;
-
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -14,6 +12,7 @@ import io.grpc.ForwardingClientCall;
 import io.grpc.ForwardingClientCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.okhttp.internal.Credentials;
 
 /**
  * AuthInterceptor intercepts GRPC API calls to adds basic authorization header

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -463,7 +463,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                 return getRingsForUTXOs(
                         txOuts,
                         getTxOutStore().getLedgerTotalTxCount(),
-                        rng
+                        DefaultRng.createInstance()
                 );
             }
         };

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -431,6 +431,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         if(!amount.getTokenId().equals(fee.getTokenId())) {
             throw new IllegalArgumentException("Mixed token type transactions not supported");
         }
+        final byte[] rngSeed = rng.nextBytes(ChaCha20Rng.SEED_SIZE_BYTES);
         UnsignedLong blockIndex = txOutStore.getCurrentBlockIndex();
         UnsignedLong tombstoneBlockIndex = blockIndex
                 .add(UnsignedLong.fromLongBits(DEFAULT_NEW_TX_BLOCK_ATTEMPTS));
@@ -463,7 +464,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                 return getRingsForUTXOs(
                         txOuts,
                         getTxOutStore().getLedgerTotalTxCount(),
-                        DefaultRng.createInstance()
+                        rng
                 );
             }
         };
@@ -528,7 +529,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                 blockchainClient.getOrFetchNetworkBlockVersion(),
                 amount.getTokenId(),
                 fee,
-                rng
+                rngSeed
         );
         txBuilder.setFee(fee);
         txBuilder.setTombstoneBlockIndex(tombstoneBlockIndex);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TransactionBuilder.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TransactionBuilder.java
@@ -26,7 +26,7 @@ final class TransactionBuilder extends Native {
         int blockVersion,
         @NonNull TokenId tokenId,
         @NonNull Amount fee,
-        @NonNull Rng rng
+        @NonNull final byte[] rngSeed
     ) throws FogReportException {
         try {
             init_jni(
@@ -36,7 +36,7 @@ final class TransactionBuilder extends Native {
                     tokenId.getId().longValue(),
                     fee.getValue().longValue()
             );
-            this.rng = ChaCha20Rng.fromSeed(rng.nextBytes(ChaCha20Rng.SEED_SIZE_BYTES));
+            this.rng = ChaCha20Rng.fromSeed(rngSeed);
         } catch (Exception exception) {
             throw new FogReportException("Unable to create TxBuilder", exception);
         }
@@ -55,7 +55,7 @@ final class TransactionBuilder extends Native {
                 blockVersion,
                 tokenId,
                 fee,
-                DefaultRng.createInstance()
+                DefaultRng.createInstance().nextBytes(ChaCha20Rng.SEED_SIZE_BYTES)
         );
     }
 

--- a/android-sdk/versions.gradle
+++ b/android-sdk/versions.gradle
@@ -22,7 +22,7 @@ versions.android = android_versions
 
 // Network
 def network_versions = [:]
-network_versions.grpc = '1.38.0'
+network_versions.grpc = '1.49.1'
 network_versions.protobuf = '3.17.0'
 versions.network = network_versions
 
@@ -39,7 +39,7 @@ testing_versions.core = '1.4.0'
 testing_versions.ext_junit = '1.1.3'
 testing_versions.espresso_core = '3.4.0'
 testing_versions.support_rules = '1.0.2'
-testing_versions.okhttp = '2.7.4'
+testing_versions.okhttp3 = '3.11.0'
 testing_versions.robolectric = '4.8'
 versions.testing = testing_versions
 
@@ -79,7 +79,7 @@ testing_deps.runner = "androidx.test:runner:$versions.testing.core"
 testing_deps.rules = "androidx.test:rules:$versions.testing.core"
 testing_deps.espresso_core = "androidx.test.espresso:espresso-core:$versions.testing.espresso_core"
 testing_deps.support_rules = "com.android.support.test:rules:$versions.testing.support_rules"
-testing_deps.okhttp = "com.squareup.okhttp:okhttp:$versions.testing.okhttp"
+testing_deps.okhttp3 = "com.squareup.okhttp3:okhttp:$versions.testing.okhttp3"
 testing_deps.robolectric = "org.robolectric:robolectric:$versions.testing.robolectric"
 deps.testing = testing_deps
 


### PR DESCRIPTION
### Motivation

This change is needed to ensure the public key of Transaction output is repeatable using any input(s) with the same RNG and seed

### In this PR
* Changed RNG calls in MobileCoinClient.prepareTransaction

