### PR TITLE
Upgrade OKHttp

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -128,6 +128,6 @@ dependencies {
     androidTestImplementation deps.testing.rules
     androidTestImplementation deps.testing.espresso_core
     androidTestImplementation deps.testing.support_rules
-    androidTestImplementation deps.testing.okhttp
+    androidTestImplementation deps.testing.okhttp3
 
 }

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
@@ -6,7 +6,7 @@ import androidx.annotation.VisibleForTesting;
 
 @VisibleForTesting
 public class Environment {
-    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.MOBILE_DEV;
+    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.TEST_NET;
 
     static public TestFogConfig getTestFogConfig() {
         return TestFogConfig.getFogConfig(CURRENT_TEST_ENV);

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/util/SimpleRequester.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/util/SimpleRequester.java
@@ -5,21 +5,20 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 
 import com.mobilecoin.lib.network.services.http.Requester.Requester;
-import com.squareup.okhttp.Authenticator;
-import com.squareup.okhttp.Credentials;
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
-import com.squareup.okhttp.Response;
 
 import java.io.IOException;
-import java.net.Proxy;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import okhttp3.Credentials;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 /**
  * Simple Requester is intended to be used for the integration tests
@@ -27,21 +26,11 @@ import java.util.Set;
 public class SimpleRequester implements Requester {
 
     private final OkHttpClient httpClient;
+    private final String basicAuthHeader;
 
     public SimpleRequester(String username, String password) {
         httpClient = new OkHttpClient();
-        final String credential = Credentials.basic(username, password);
-        httpClient.setAuthenticator(new Authenticator() {
-            @Override
-            public Request authenticate(Proxy proxy, Response response) throws IOException {
-                return response.request().newBuilder().header("Authorization", credential).build();
-            }
-
-            @Override
-            public Request authenticateProxy(Proxy proxy, Response response) throws IOException {
-                return response.request().newBuilder().header("Proxy-Authorization", credential).build();
-            }
-        });
+        basicAuthHeader = Credentials.basic(username, password);
     }
 
     @NonNull
@@ -58,6 +47,7 @@ public class SimpleRequester implements Requester {
                 body
         );
 
+        headers.put("Authorization", basicAuthHeader);
         Request request = new Request.Builder()
                 .method(httpMethod, requestBody)
                 .headers(Headers.of(headers))

--- a/android-sdk/src/grpc/java/com/mobilecoin/lib/network/grpc/AuthInterceptor.java
+++ b/android-sdk/src/grpc/java/com/mobilecoin/lib/network/grpc/AuthInterceptor.java
@@ -4,8 +4,6 @@ package com.mobilecoin.lib.network.grpc;
 
 import androidx.annotation.NonNull;
 
-import com.squareup.okhttp.Credentials;
-
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -14,6 +12,7 @@ import io.grpc.ForwardingClientCall;
 import io.grpc.ForwardingClientCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.okhttp.internal.Credentials;
 
 /**
  * AuthInterceptor intercepts GRPC API calls to adds basic authorization header

--- a/android-sdk/versions.gradle
+++ b/android-sdk/versions.gradle
@@ -22,7 +22,7 @@ versions.android = android_versions
 
 // Network
 def network_versions = [:]
-network_versions.grpc = '1.38.0'
+network_versions.grpc = '1.49.1'
 network_versions.protobuf = '3.17.0'
 versions.network = network_versions
 
@@ -39,7 +39,7 @@ testing_versions.core = '1.4.0'
 testing_versions.ext_junit = '1.1.3'
 testing_versions.espresso_core = '3.4.0'
 testing_versions.support_rules = '1.0.2'
-testing_versions.okhttp = '2.7.4'
+testing_versions.okhttp3 = '3.11.0'
 testing_versions.robolectric = '4.8'
 versions.testing = testing_versions
 
@@ -79,7 +79,7 @@ testing_deps.runner = "androidx.test:runner:$versions.testing.core"
 testing_deps.rules = "androidx.test:rules:$versions.testing.core"
 testing_deps.espresso_core = "androidx.test.espresso:espresso-core:$versions.testing.espresso_core"
 testing_deps.support_rules = "com.android.support.test:rules:$versions.testing.support_rules"
-testing_deps.okhttp = "com.squareup.okhttp:okhttp:$versions.testing.okhttp"
+testing_deps.okhttp3 = "com.squareup.okhttp3:okhttp:$versions.testing.okhttp3"
 testing_deps.robolectric = "org.robolectric:robolectric:$versions.testing.robolectric"
 deps.testing = testing_deps
 


### PR DESCRIPTION
### Motivation

The outdated OKHttp library fails some HTTP/2 requests

### In this PR
* Replaced OKHttp with OkHttp3
