### PR TITLE
Implement token_id field in PaymentRequest

### DIFF
--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/PrintableWrapperTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/PrintableWrapperTest.java
@@ -61,9 +61,11 @@ public class PrintableWrapperTest {
     @Test
     public void test_payment_request_payload() throws SerializationException {
         PublicAddress publicAddress = TestKeysManager.getNextAccountKey().getPublicAddress();
+        TokenId tokenId = TokenId.MOB;
         PaymentRequest paymentRequest = new PaymentRequest(publicAddress,
                 PAYLOAD_AMOUNT,
-                MEMO
+                MEMO,
+                tokenId
         );
         PrintableWrapper printableWrapper = PrintableWrapper.fromPaymentRequest(paymentRequest);
         Assert.assertFalse(
@@ -96,6 +98,9 @@ public class PrintableWrapperTest {
                 printableWrapper.getPaymentRequest(),
                 paymentRequest
         );
+        Assert.assertEquals("Payment request must include token id",
+                printableWrapper.getPaymentRequest().getTokenId(),
+                tokenId);
     }
 
     @Test

--- a/android-sdk/src/main/java/com/mobilecoin/lib/PaymentRequest.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/PaymentRequest.java
@@ -15,15 +15,18 @@ public final class PaymentRequest {
     private final PublicAddress publicAddress;
     private final UnsignedLong value;
     private final String memo;
+    private final TokenId tokenId;
 
     public PaymentRequest(
             @NonNull PublicAddress publicAddress,
             @NonNull UnsignedLong value,
-            @NonNull String memo
+            @NonNull String memo,
+            @NonNull TokenId tokenId
     ) {
         this.publicAddress = publicAddress;
         this.value = value;
         this.memo = memo;
+        this.tokenId = tokenId;
     }
 
     @NonNull
@@ -31,10 +34,14 @@ public final class PaymentRequest {
             throws SerializationException {
         Logger.i(TAG, "Deserializing PaymentRequest from protobuf");
         PublicAddress publicAddress = PublicAddress.fromProtoBufObject(protoBuf.getPublicAddress());
+        TokenId tokenId = TokenId.from(
+                UnsignedLong.fromLongBits(protoBuf.getTokenId())
+        );
         return new PaymentRequest(
                 publicAddress,
                 UnsignedLong.fromLongBits(protoBuf.getValue()),
-                protoBuf.getMemo()
+                protoBuf.getMemo(),
+                tokenId
         );
     }
 
@@ -57,16 +64,24 @@ public final class PaymentRequest {
     }
 
     @NonNull
+    public TokenId getTokenId() {
+        return tokenId;
+    }
+
+    @NonNull
     Printable.PaymentRequest toProtoBufObject() {
         Logger.i(TAG, "Serializing to protobuf");
-        return Printable.PaymentRequest.newBuilder().setMemo(getMemo())
-                .setPublicAddress(getPublicAddress().toProtoBufObject()).setValue(getValue().longValue())
+        return Printable.PaymentRequest.newBuilder()
+                .setMemo(getMemo())
+                .setPublicAddress(getPublicAddress().toProtoBufObject())
+                .setValue(getValue().longValue())
+                .setTokenId(tokenId.getId().longValue())
                 .build();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(publicAddress, value, memo);
+        return Objects.hash(publicAddress, value, memo, tokenId);
     }
 
     @Override
@@ -76,6 +91,7 @@ public final class PaymentRequest {
         PaymentRequest that = (PaymentRequest) o;
         return publicAddress.equals(that.publicAddress) &&
                 value.equals(that.value) &&
+                tokenId.equals(that.tokenId) &&
                 memo.equals(that.memo);
     }
 }


### PR DESCRIPTION
### Motivation

`PaymentRequest` now includes the `token_id` field to handle multiple tokens.
This PR exposes the new `token_id` field.
