### PR TITLE
RTH Payment ID Memos

### DIFF
--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
@@ -6,7 +6,7 @@ import androidx.annotation.VisibleForTesting;
 
 @VisibleForTesting
 public class Environment {
-    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.TEST_NET;
+    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.MOBILE_DEV;
 
     static public TestFogConfig getTestFogConfig() {
         return TestFogConfig.getFogConfig(CURRENT_TEST_ENV);

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/Environment.java
@@ -6,7 +6,7 @@ import androidx.annotation.VisibleForTesting;
 
 @VisibleForTesting
 public class Environment {
-    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.MOBILE_DEV;
+    public static final TestEnvironment CURRENT_TEST_ENV = TestEnvironment.TEST_NET;
 
     static public TestFogConfig getTestFogConfig() {
         return TestFogConfig.getFogConfig(CURRENT_TEST_ENV);

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TxOutMemoBuilderTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TxOutMemoBuilderTest.java
@@ -32,4 +32,14 @@ public class TxOutMemoBuilderTest {
         .createSenderPaymentRequestAndDestinationRTHMemoBuilder(accountKey, paymentRequestId);
   }
 
+  @Test
+  public void createSenderPaymentIntentAndDestinationRTHMemoBuilder_validAccountKey_paymentIntentId_constructsRTHMemoBuilder()
+          throws Exception {
+    AccountKey accountKey = TestKeysManager.getNextAccountKey();
+    UnsignedLong paymentIntentId = UnsignedLong.TEN;
+
+    TxOutMemoBuilder txOutMemoBuilder = TxOutMemoBuilder
+            .createSenderPaymentIntentAndDestinationRTHMemoBuilder(accountKey, paymentIntentId);
+  }
+
 }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationMemo.java
@@ -9,9 +9,9 @@ import com.mobilecoin.lib.exceptions.InvalidTxOutMemoException;
 import java.util.Objects;
 
 /** Represents a destination memo, which corresponds to the "DestinationMemo" specification. */
-public final class DestinationMemo extends TxOutMemo {
+public class DestinationMemo extends TxOutMemo {
 
-  private static final String TAG = SenderMemo.class.getSimpleName();
+  private static final String TAG = DestinationMemo.class.getSimpleName();
 
   private final DestinationMemoData destinationMemoData;
 
@@ -58,7 +58,7 @@ public final class DestinationMemo extends TxOutMemo {
   /** Retrieves the destination memo data. **/
   public DestinationMemoData getDestinationMemoData() throws InvalidTxOutMemoException {
     if(!validated) {
-      throw new InvalidTxOutMemoException("The sender memo is invalid.");
+      throw new InvalidTxOutMemoException("The Destination is invalid.");
     }
     return destinationMemoData;
   }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationMemo.java
@@ -9,7 +9,7 @@ import com.mobilecoin.lib.exceptions.InvalidTxOutMemoException;
 import java.util.Objects;
 
 /** Represents a destination memo, which corresponds to the "DestinationMemo" specification. */
-public class DestinationMemo extends TxOutMemo {
+public final class DestinationMemo extends TxOutMemo {
 
   private static final String TAG = DestinationMemo.class.getSimpleName();
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationMemo.java
@@ -58,7 +58,7 @@ public class DestinationMemo extends TxOutMemo {
   /** Retrieves the destination memo data. **/
   public DestinationMemoData getDestinationMemoData() throws InvalidTxOutMemoException {
     if(!validated) {
-      throw new InvalidTxOutMemoException("The Destination is invalid.");
+      throw new InvalidTxOutMemoException("The destination memo is invalid.");
     }
     return destinationMemoData;
   }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemo.java
@@ -8,7 +8,18 @@ import com.mobilecoin.lib.exceptions.InvalidTxOutMemoException;
 
 import java.util.Objects;
 
-// TODO: doc
+/***
+ * This class represents a {@link DestinationMemo} tied to a specific <strong>payment intent</strong>.
+ *
+ * This should be interpreted the same as a {@link DestinationMemo} but has one additional field, a <strong>payment intent</strong> ID.
+ * This memo is paired with a {@link SenderWithPaymentIntentMemo} which is sent to the recipient and contains the same <strong>payment intent</strong> ID.
+ *
+ * @see DestinationMemo
+ * @see SenderWithPaymentIntentMemo
+ * @see DestinationWithPaymentIntentMemoData
+ * @see TxOutMemo
+ * @since 2.0.0
+ */
 public class DestinationWithPaymentIntentMemo extends TxOutMemo {
 
     private static final String TAG = DestinationWithPaymentIntentMemo.class.getSimpleName();
@@ -57,7 +68,19 @@ public class DestinationWithPaymentIntentMemo extends TxOutMemo {
         );
     }
 
-    // TODO: Doc
+    /**
+     * Returns the {@link DestinationWithPaymentIntentMemoData} for this {@link DestinationWithPaymentIntentMemo} if valid.
+     *
+     * If validation of the memo fails, an {@link InvalidTxOutMemoException} is thrown
+     *
+     * @return the {@link DestinationWithPaymentIntentMemoData}, if valid
+     * @throws InvalidTxOutMemoException if validation of the memo fails
+     *
+     * @see DestinationWithPaymentIntentMemoData
+     * @see MemoData
+     * @see InvalidTxOutMemoException
+     * @since 2.0.0
+     */
     public DestinationWithPaymentIntentMemoData getDestinationWithPaymentIntentMemoData() throws InvalidTxOutMemoException {
         if (!validated) {
             throw new InvalidTxOutMemoException("The DestinationWithPaymentIntentMemo is invalid.");

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemo.java
@@ -1,0 +1,119 @@
+package com.mobilecoin.lib;
+
+import android.os.Parcel;
+
+import androidx.annotation.NonNull;
+
+import com.mobilecoin.lib.exceptions.InvalidTxOutMemoException;
+
+import java.util.Objects;
+
+// TODO: doc
+public class DestinationWithPaymentIntentMemo extends TxOutMemo {
+
+    private static final String TAG = DestinationWithPaymentIntentMemo.class.getSimpleName();
+
+    private final DestinationWithPaymentIntentMemoData destinationWithPaymentIntentMemoData;
+
+    /**
+     * Creates a {@link DestinationWithPaymentIntentMemo} from decrypted memo data that hasn't been validated yet.
+     *
+     * @param accountKey
+     * @param txOut
+     * @param memoData   - The {@value TxOutMemo#TX_OUT_MEMO_DATA_SIZE_BYTES} bytes that correspond to the memo payload.
+     **/
+    static DestinationWithPaymentIntentMemo create(
+            @NonNull final AccountKey accountKey,
+            @NonNull final TxOut txOut,
+            @NonNull final byte[] memoData) {
+        if (memoData.length != TxOutMemo.TX_OUT_MEMO_DATA_SIZE_BYTES) {
+            throw new IllegalArgumentException("Memo data byte array must have a length of " +
+                    TxOutMemo.TX_OUT_MEMO_DATA_SIZE_BYTES + ". Instead, the length was: " + memoData.length);
+        }
+        return new DestinationWithPaymentIntentMemo(accountKey, txOut, memoData);
+    }
+
+    private DestinationWithPaymentIntentMemo(final AccountKey accountKey, final TxOut txOut, final byte[] memoData) {
+        super(TxOutMemoType.DESTINATION_WITH_PAYMENT_INTENT);
+        try {
+            init_jni_from_memo_data(memoData);
+        } catch (Exception e) {
+            IllegalArgumentException illegalArgumentException =
+                    new IllegalArgumentException("Failed to create an AccountKey", e);
+            Util.logException(TAG, illegalArgumentException);
+            throw illegalArgumentException;
+        }
+        validated = is_valid(accountKey, txOut);
+        AddressHash addressHash = AddressHash.createAddressHash(get_address_hash_data());
+        UnsignedLong fee = UnsignedLong.fromLongBits(get_fee());
+        UnsignedLong totalOutlay = UnsignedLong.fromLongBits(get_total_outlay());
+        UnsignedLong paymentIntentId = UnsignedLong.fromLongBits(get_payment_intent_id());
+        destinationWithPaymentIntentMemoData = DestinationWithPaymentIntentMemoData.create(
+                addressHash,
+                get_number_of_recipients(),
+                fee,
+                totalOutlay,
+                paymentIntentId
+        );
+    }
+
+    // TODO: Doc
+    public DestinationWithPaymentIntentMemoData getDestinationWithPaymentIntentMemoData() throws InvalidTxOutMemoException {
+        if (!validated) {
+            throw new InvalidTxOutMemoException("The DestinationWithPaymentIntentMemo is invalid.");
+        }
+        return destinationWithPaymentIntentMemoData;
+    }
+
+    private DestinationWithPaymentIntentMemo(@NonNull Parcel parcel) {
+        super(TxOutMemoType.DESTINATION_WITH_PAYMENT_INTENT);
+        destinationWithPaymentIntentMemoData = parcel.readParcelable(DestinationWithPaymentIntentMemoData.class.getClassLoader());
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel parcel, int flags) {
+        parcel.writeParcelable(destinationWithPaymentIntentMemoData, flags);
+    }
+
+    public static Creator<DestinationWithPaymentIntentMemo> CREATOR = new Creator<DestinationWithPaymentIntentMemo>() {
+        @Override
+        public DestinationWithPaymentIntentMemo createFromParcel(@NonNull Parcel parcel) {
+            return new DestinationWithPaymentIntentMemo(parcel);
+        }
+
+        @Override
+        public DestinationWithPaymentIntentMemo[] newArray(int length) {
+            return new DestinationWithPaymentIntentMemo[length];
+        }
+    };
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof DestinationWithPaymentIntentMemo) {
+            DestinationWithPaymentIntentMemo that = (DestinationWithPaymentIntentMemo) o;
+            return Objects.equals(this.memoType, that.memoType) &&
+                    Objects.equals(this.destinationWithPaymentIntentMemoData, that.destinationWithPaymentIntentMemoData);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(memoType, destinationWithPaymentIntentMemoData);
+    }
+
+    private native void init_jni_from_memo_data(byte[] memoData);
+
+    private native boolean is_valid(@NonNull AccountKey accountKey, @NonNull TxOut txOut);
+
+    private native byte[] get_address_hash_data();
+
+    private native short get_number_of_recipients();
+
+    private native long get_fee();
+
+    private native long get_total_outlay();
+
+    private native long get_payment_intent_id();
+
+}

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemo.java
@@ -20,7 +20,7 @@ import java.util.Objects;
  * @see TxOutMemo
  * @since 2.0.0
  */
-public class DestinationWithPaymentIntentMemo extends TxOutMemo {
+public final class DestinationWithPaymentIntentMemo extends TxOutMemo {
 
     private static final String TAG = DestinationWithPaymentIntentMemo.class.getSimpleName();
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemoData.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemoData.java
@@ -6,7 +6,17 @@ import androidx.annotation.NonNull;
 
 import java.util.Objects;
 
-// TODO: doc
+/**
+ * Contains data associated with a {@link DestinationWithPaymentIntentMemo}.
+ *
+ * The data has been validated, which means that the account accessing this {@link DestinationWithPaymentIntentMemoData}
+ * is the same one which send the associated {@link Transaction}.
+ *
+ * @see DestinationWithPaymentIntentMemo
+ * @see MemoData
+ * @see AddressHash
+ * @since 2.0.0
+ */
 public class DestinationWithPaymentIntentMemoData extends MemoData {
 
     @NonNull
@@ -14,8 +24,7 @@ public class DestinationWithPaymentIntentMemoData extends MemoData {
 
     private final int numberOfRecipients;
 
-    // TODO: doc
-    public static DestinationWithPaymentIntentMemoData create(
+    static DestinationWithPaymentIntentMemoData create(
             @NonNull final AddressHash addressHash,
             final int numberOfRecipients,
             @NonNull final UnsignedLong fee,
@@ -39,24 +48,80 @@ public class DestinationWithPaymentIntentMemoData extends MemoData {
         this.paymentIntentId = paymentIntentId;
     }
 
-    // TODO: doc
+    /**
+     * Gets the number of recipients from the {@link Transaction} that created the associated {@link DestinationWithPaymentIntentMemo}
+     *
+     * As of 2.0.0, {@link Transaction}s built using this SDK are limited to a single recipient. As a result,
+     * for {@link Transaction}s built using this SDK, this value will always be 1. This may not be the case if the
+     * account is also used with different client implementation.
+     *
+     * @return the number of recipients of the associated {@link Transaction}
+     *
+     * @see MobileCoinClient#prepareTransaction(PublicAddress, Amount, Amount, TxOutMemoBuilder)
+     * @since 2.0.0
+     */
     public int getNumberOfRecipients() {
         return numberOfRecipients;
     }
 
-    // TODO: doc
+    /**
+     * Gets the fee that was paid to submit the associated {@link Transaction}
+     *
+     * The value returned does not come with a {@link TokenId}. To get the {@link TokenId} of the fee,
+     * check the {@link OwnedTxOut#getAmount()} of the {@link OwnedTxOut} to which the {@link DestinationWithPaymentIntentMemo}
+     * is attached.
+     *
+     * @return the value of the fee paid to submit the {@link Transaction}
+     *
+     * @see MobileCoinClient#prepareTransaction(PublicAddress, Amount, Amount, TxOutMemoBuilder)
+     * @see OwnedTxOut
+     * @see OwnedTxOut#getAmount()
+     * @see Amount
+     * @see Amount#getTokenId()
+     * @see OwnedTxOut#getTxOutMemo()
+     * @since 2.0.0
+     */
     @NonNull
     public UnsignedLong getFee() {
         return fee;
     }
 
-    //TODO: doc
+    /**
+     * Gets the <strong>total outlay</strong> of the associated {@link Transaction}.
+     *
+     * The <strong>total outlay</strong> is the amount being sent plus fees.
+     * The value returned does not come with a {@link TokenId}. To get the {@link TokenId} of the fee,
+     * check the {@link OwnedTxOut#getAmount()} of the {@link OwnedTxOut} to which the {@link DestinationWithPaymentIntentMemo}
+     * is attached.
+     *
+     * @return the value of the <strong>total outlay</strong> of the {@link Transaction}
+     *
+     * @see MobileCoinClient#prepareTransaction(PublicAddress, Amount, Amount, TxOutMemoBuilder)
+     * @see OwnedTxOut
+     * @see OwnedTxOut#getAmount()
+     * @see Amount
+     * @see Amount#getTokenId()
+     * @see OwnedTxOut#getTxOutMemo()
+     * @since 2.0.0
+     */
     @NonNull
     public UnsignedLong getTotalOutlay() {
         return totalOutlay;
     }
 
-    //TODO: doc
+    /**
+     * Gets the <strong>payment intent</strong> ID stored in this {@link DestinationWithPaymentIntentMemoData}
+     *
+     * For additional information about this field, see
+     * {@link TxOutMemoBuilder#createSenderPaymentIntentAndDestinationRTHMemoBuilder(AccountKey, UnsignedLong)}.
+     *
+     * @return the ID of a <strong>payment intent</strong>
+     *
+     * @see TxOutMemoBuilder#createSenderPaymentIntentAndDestinationRTHMemoBuilder(AccountKey, UnsignedLong)
+     * @see DestinationWithPaymentIntentMemo
+     * @see SenderWithPaymentIntentMemoData#getPaymentIntentId()
+     * @since 2.0.0
+     */
     @NonNull
     public UnsignedLong getPaymentIntentId() {
         return paymentIntentId;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemoData.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemoData.java
@@ -1,0 +1,115 @@
+package com.mobilecoin.lib;
+
+import android.os.Parcel;
+
+import androidx.annotation.NonNull;
+
+import java.util.Objects;
+
+// TODO: doc
+public class DestinationWithPaymentIntentMemoData extends MemoData {
+
+    @NonNull
+    private final UnsignedLong fee, totalOutlay, paymentIntentId;
+
+    private final int numberOfRecipients;
+
+    // TODO: doc
+    public static DestinationWithPaymentIntentMemoData create(
+            @NonNull final AddressHash addressHash,
+            final int numberOfRecipients,
+            @NonNull final UnsignedLong fee,
+            @NonNull final UnsignedLong totalOutlay,
+            @NonNull final UnsignedLong paymentRequestId
+    ) {
+        return new DestinationWithPaymentIntentMemoData(addressHash, numberOfRecipients, fee, totalOutlay, paymentRequestId);
+    }
+
+    private DestinationWithPaymentIntentMemoData(
+            @NonNull final AddressHash addressHash,
+            final int numberOfRecipients,
+            @NonNull final UnsignedLong fee,
+            @NonNull final UnsignedLong totalOutlay,
+            @NonNull final UnsignedLong paymentIntentId
+    ) {
+        super(addressHash);
+        this.numberOfRecipients = numberOfRecipients;
+        this.fee = fee;
+        this.totalOutlay = totalOutlay;
+        this.paymentIntentId = paymentIntentId;
+    }
+
+    // TODO: doc
+    public int getNumberOfRecipients() {
+        return numberOfRecipients;
+    }
+
+    // TODO: doc
+    @NonNull
+    public UnsignedLong getFee() {
+        return fee;
+    }
+
+    //TODO: doc
+    @NonNull
+    public UnsignedLong getTotalOutlay() {
+        return totalOutlay;
+    }
+
+    //TODO: doc
+    @NonNull
+    public UnsignedLong getPaymentIntentId() {
+        return paymentIntentId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DestinationWithPaymentIntentMemoData that = (DestinationWithPaymentIntentMemoData) o;
+        return numberOfRecipients == that.numberOfRecipients &&
+                Objects.equals(addressHash, that.addressHash) &&
+                Objects.equals(fee, that.fee) &&
+                Objects.equals(totalOutlay, that.totalOutlay) &&
+                Objects.equals(paymentIntentId, that.paymentIntentId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(addressHash, numberOfRecipients, fee, totalOutlay, paymentIntentId);
+    }
+
+    private DestinationWithPaymentIntentMemoData(@NonNull Parcel parcel) {
+        super(parcel.readParcelable(AddressHash.class.getClassLoader()));
+        fee = parcel.readParcelable(UnsignedLong.class.getClassLoader());
+        totalOutlay = parcel.readParcelable(UnsignedLong.class.getClassLoader());
+        numberOfRecipients = parcel.readInt();
+        paymentIntentId = parcel.readParcelable(UnsignedLong.class.getClassLoader());
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel parcel, int flags) {
+        super.writeToParcel(parcel, flags);
+        parcel.writeParcelable(fee, flags);
+        parcel.writeParcelable(totalOutlay, flags);
+        parcel.writeInt(numberOfRecipients);
+        parcel.writeParcelable(paymentIntentId, flags);
+    }
+
+    public static final Creator<DestinationWithPaymentIntentMemoData> CREATOR = new Creator<DestinationWithPaymentIntentMemoData>() {
+        @Override
+        public DestinationWithPaymentIntentMemoData createFromParcel(@NonNull Parcel parcel) {
+            return new DestinationWithPaymentIntentMemoData(parcel);
+        }
+
+        @Override
+        public DestinationWithPaymentIntentMemoData[] newArray(int length) {
+            return new DestinationWithPaymentIntentMemoData[length];
+        }
+    };
+
+}

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemoData.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemoData.java
@@ -17,7 +17,7 @@ import java.util.Objects;
  * @see AddressHash
  * @since 2.0.0
  */
-public class DestinationWithPaymentIntentMemoData extends MemoData {
+public final class DestinationWithPaymentIntentMemoData extends MemoData {
 
     @NonNull
     private final UnsignedLong fee, totalOutlay, paymentIntentId;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemo.java
@@ -8,7 +8,18 @@ import com.mobilecoin.lib.exceptions.InvalidTxOutMemoException;
 
 import java.util.Objects;
 
-// TODO: doc
+/***
+ * This class represents a {@link DestinationMemo} tied to a specific <strong>payment request</strong>.
+ *
+ * This should be interpreted the same as a {@link DestinationMemo} but has one additional field, a <strong>payment request</strong> ID.
+ * This memo is paired with a {@link SenderWithPaymentRequestMemo} which is sent to the recipient and contains the same <strong>payment request</strong> ID.
+ *
+ * @see DestinationMemo
+ * @see SenderWithPaymentRequestMemo
+ * @see DestinationWithPaymentRequestMemoData
+ * @see TxOutMemo
+ * @since 2.0.0
+ */
 public class DestinationWithPaymentRequestMemo extends TxOutMemo {
 
     private static final String TAG = DestinationWithPaymentRequestMemo.class.getSimpleName();
@@ -57,7 +68,19 @@ public class DestinationWithPaymentRequestMemo extends TxOutMemo {
         );
     }
 
-    // TODO: Doc
+    /**
+     * Returns the {@link DestinationWithPaymentRequestMemoData} for this {@link DestinationWithPaymentRequestMemo} if valid.
+     *
+     * If validation of the memo fails, an {@link InvalidTxOutMemoException} is thrown
+     *
+     * @return the {@link DestinationWithPaymentRequestMemoData}, if valid
+     * @throws InvalidTxOutMemoException if validation of the memo fails
+     *
+     * @see DestinationWithPaymentRequestMemoData
+     * @see MemoData
+     * @see InvalidTxOutMemoException
+     * @since 2.0.0
+     */
     public DestinationWithPaymentRequestMemoData getDestinationWithPaymentRequestMemoData() throws InvalidTxOutMemoException {
         if (!validated) {
             throw new InvalidTxOutMemoException("The DestinationWithPaymentRequestMemo is invalid.");

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemo.java
@@ -20,7 +20,7 @@ import java.util.Objects;
  * @see TxOutMemo
  * @since 2.0.0
  */
-public class DestinationWithPaymentRequestMemo extends TxOutMemo {
+public final class DestinationWithPaymentRequestMemo extends TxOutMemo {
 
     private static final String TAG = DestinationWithPaymentRequestMemo.class.getSimpleName();
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemo.java
@@ -1,0 +1,119 @@
+package com.mobilecoin.lib;
+
+import android.os.Parcel;
+
+import androidx.annotation.NonNull;
+
+import com.mobilecoin.lib.exceptions.InvalidTxOutMemoException;
+
+import java.util.Objects;
+
+// TODO: doc
+public class DestinationWithPaymentRequestMemo extends TxOutMemo {
+
+    private static final String TAG = DestinationWithPaymentRequestMemo.class.getSimpleName();
+
+    private final DestinationWithPaymentRequestMemoData destinationWithPaymentRequestMemoData;
+
+    /**
+     * Creates a {@link DestinationWithPaymentRequestMemo} from decrypted memo data that hasn't been validated yet.
+     *
+     * @param accountKey
+     * @param txOut
+     * @param memoData   - The {@value TxOutMemo#TX_OUT_MEMO_DATA_SIZE_BYTES} bytes that correspond to the memo payload.
+     **/
+    static DestinationWithPaymentRequestMemo create(
+            @NonNull final AccountKey accountKey,
+            @NonNull final TxOut txOut,
+            @NonNull final byte[] memoData) {
+        if (memoData.length != TxOutMemo.TX_OUT_MEMO_DATA_SIZE_BYTES) {
+            throw new IllegalArgumentException("Memo data byte array must have a length of " +
+                    TxOutMemo.TX_OUT_MEMO_DATA_SIZE_BYTES + ". Instead, the length was: " + memoData.length);
+        }
+        return new DestinationWithPaymentRequestMemo(accountKey, txOut, memoData);
+    }
+
+    private DestinationWithPaymentRequestMemo(final AccountKey accountKey, final TxOut txOut, final byte[] memoData) {
+        super(TxOutMemoType.DESTINATION_WITH_PAYMENT_REQUEST);
+        try {
+            init_jni_from_memo_data(memoData);
+        } catch (Exception e) {
+            IllegalArgumentException illegalArgumentException =
+                    new IllegalArgumentException("Failed to create an AccountKey", e);
+            Util.logException(TAG, illegalArgumentException);
+            throw illegalArgumentException;
+        }
+        validated = is_valid(accountKey, txOut);
+        AddressHash addressHash = AddressHash.createAddressHash(get_address_hash_data());
+        UnsignedLong fee = UnsignedLong.fromLongBits(get_fee());
+        UnsignedLong totalOutlay = UnsignedLong.fromLongBits(get_total_outlay());
+        UnsignedLong paymentRequestId = UnsignedLong.fromLongBits(get_payment_request_id());
+        destinationWithPaymentRequestMemoData = DestinationWithPaymentRequestMemoData.create(
+                addressHash,
+                get_number_of_recipients(),
+                fee,
+                totalOutlay,
+                paymentRequestId
+        );
+    }
+
+    // TODO: Doc
+    public DestinationWithPaymentRequestMemoData getDestinationWithPaymentRequestMemoData() throws InvalidTxOutMemoException {
+        if (!validated) {
+            throw new InvalidTxOutMemoException("The DestinationWithPaymentRequestMemo is invalid.");
+        }
+        return destinationWithPaymentRequestMemoData;
+    }
+
+    private DestinationWithPaymentRequestMemo(@NonNull Parcel parcel) {
+        super(TxOutMemoType.DESTINATION_WITH_PAYMENT_REQUEST);
+        destinationWithPaymentRequestMemoData = parcel.readParcelable(DestinationWithPaymentRequestMemo.class.getClassLoader());
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel parcel, int flags) {
+        parcel.writeParcelable(destinationWithPaymentRequestMemoData, flags);
+    }
+
+    public static Creator<DestinationWithPaymentRequestMemo> CREATOR = new Creator<DestinationWithPaymentRequestMemo>() {
+        @Override
+        public DestinationWithPaymentRequestMemo createFromParcel(@NonNull Parcel parcel) {
+            return new DestinationWithPaymentRequestMemo(parcel);
+        }
+
+        @Override
+        public DestinationWithPaymentRequestMemo[] newArray(int length) {
+            return new DestinationWithPaymentRequestMemo[length];
+        }
+    };
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof DestinationWithPaymentRequestMemo) {
+            DestinationWithPaymentRequestMemo that = (DestinationWithPaymentRequestMemo) o;
+            return Objects.equals(this.memoType, that.memoType) &&
+                    Objects.equals(this.destinationWithPaymentRequestMemoData, that.destinationWithPaymentRequestMemoData);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(memoType, destinationWithPaymentRequestMemoData);
+    }
+
+    private native void init_jni_from_memo_data(byte[] memoData);
+
+    private native boolean is_valid(@NonNull AccountKey accountKey, @NonNull TxOut txOut);
+
+    private native byte[] get_address_hash_data();
+
+    private native short get_number_of_recipients();
+
+    private native long get_fee();
+
+    private native long get_total_outlay();
+
+    private native long get_payment_request_id();
+
+}

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemoData.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemoData.java
@@ -17,7 +17,7 @@ import java.util.Objects;
  * @see AddressHash
  * @since 2.0.0
  */
-public class DestinationWithPaymentRequestMemoData extends MemoData {
+public final class DestinationWithPaymentRequestMemoData extends MemoData {
 
     @NonNull
     private final UnsignedLong fee, totalOutlay, paymentRequestId;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemoData.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemoData.java
@@ -6,7 +6,17 @@ import androidx.annotation.NonNull;
 
 import java.util.Objects;
 
-// TODO: doc
+/**
+ * Contains data associated with a {@link DestinationWithPaymentRequestMemo}.
+ *
+ * The data has been validated, which means that the account accessing this {@link DestinationWithPaymentRequestMemoData}
+ * is the same one which send the associated {@link Transaction}.
+ *
+ * @see DestinationWithPaymentRequestMemo
+ * @see MemoData
+ * @see AddressHash
+ * @since 2.0.0
+ */
 public class DestinationWithPaymentRequestMemoData extends MemoData {
 
     @NonNull
@@ -14,8 +24,7 @@ public class DestinationWithPaymentRequestMemoData extends MemoData {
 
     private final int numberOfRecipients;
 
-    // TODO: doc
-    public static DestinationWithPaymentRequestMemoData create(
+    static DestinationWithPaymentRequestMemoData create(
             @NonNull final AddressHash addressHash,
             final int numberOfRecipients,
             @NonNull final UnsignedLong fee,
@@ -39,24 +48,80 @@ public class DestinationWithPaymentRequestMemoData extends MemoData {
         this.paymentRequestId = paymentRequestId;
     }
 
-    // TODO: doc
+    /**
+     * Gets the number of recipients from the {@link Transaction} that created the associated {@link DestinationWithPaymentRequestMemo}
+     *
+     * As of 2.0.0, {@link Transaction}s built using this SDK are limited to a single recipient. As a result,
+     * for {@link Transaction}s built using this SDK, this value will always be 1. This may not be the case if the
+     * account is also used with different client implementation.
+     *
+     * @return the number of recipients of the associated {@link Transaction}
+     *
+     * @see MobileCoinClient#prepareTransaction(PublicAddress, Amount, Amount, TxOutMemoBuilder)
+     * @since 2.0.0
+     */
     public int getNumberOfRecipients() {
         return numberOfRecipients;
     }
 
-    // TODO: doc
+    /**
+     * Gets the fee that was paid to submit the associated {@link Transaction}
+     *
+     * The value returned does not come with a {@link TokenId}. To get the {@link TokenId} of the fee,
+     * check the {@link OwnedTxOut#getAmount()} of the {@link OwnedTxOut} to which the {@link DestinationWithPaymentRequestMemo}
+     * is attached.
+     *
+     * @return the value of the fee paid to submit the {@link Transaction}
+     *
+     * @see MobileCoinClient#prepareTransaction(PublicAddress, Amount, Amount, TxOutMemoBuilder)
+     * @see OwnedTxOut
+     * @see OwnedTxOut#getAmount()
+     * @see Amount
+     * @see Amount#getTokenId()
+     * @see OwnedTxOut#getTxOutMemo()
+     * @since 2.0.0
+     */
     @NonNull
     public UnsignedLong getFee() {
         return fee;
     }
 
-    //TODO: doc
+    /**
+     * Gets the <strong>total outlay</strong> of the associated {@link Transaction}.
+     *
+     * The <strong>total outlay</strong> is the amount being sent plus fees.
+     * The value returned does not come with a {@link TokenId}. To get the {@link TokenId} of the fee,
+     * check the {@link OwnedTxOut#getAmount()} of the {@link OwnedTxOut} to which the {@link DestinationWithPaymentRequestMemo}
+     * is attached.
+     *
+     * @return the value of the <strong>total outlay</strong> of the {@link Transaction}
+     *
+     * @see MobileCoinClient#prepareTransaction(PublicAddress, Amount, Amount, TxOutMemoBuilder)
+     * @see OwnedTxOut
+     * @see OwnedTxOut#getAmount()
+     * @see Amount
+     * @see Amount#getTokenId()
+     * @see OwnedTxOut#getTxOutMemo()
+     * @since 2.0.0
+     */
     @NonNull
     public UnsignedLong getTotalOutlay() {
         return totalOutlay;
     }
 
-    //TODO: doc
+    /**
+     * Gets the <strong>payment request</strong> ID stored in this {@link DestinationWithPaymentRequestMemoData}
+     *
+     * For additional information about this field, see
+     * {@link TxOutMemoBuilder#createSenderPaymentRequestAndDestinationRTHMemoBuilder(AccountKey, UnsignedLong)}.
+     *
+     * @return the ID of a <strong>payment request</strong>
+     *
+     * @see TxOutMemoBuilder#createSenderPaymentRequestAndDestinationRTHMemoBuilder(AccountKey, UnsignedLong)
+     * @see DestinationWithPaymentRequestMemo
+     * @see SenderWithPaymentRequestMemoData#getPaymentRequestId()
+     * @since 2.0.0
+     */
     @NonNull
     public UnsignedLong getPaymentRequestId() {
         return paymentRequestId;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemoData.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemoData.java
@@ -1,0 +1,115 @@
+package com.mobilecoin.lib;
+
+import android.os.Parcel;
+
+import androidx.annotation.NonNull;
+
+import java.util.Objects;
+
+// TODO: doc
+public class DestinationWithPaymentRequestMemoData extends MemoData {
+
+    @NonNull
+    private final UnsignedLong fee, totalOutlay, paymentRequestId;
+
+    private final int numberOfRecipients;
+
+    // TODO: doc
+    public static DestinationWithPaymentRequestMemoData create(
+            @NonNull final AddressHash addressHash,
+            final int numberOfRecipients,
+            @NonNull final UnsignedLong fee,
+            @NonNull final UnsignedLong totalOutlay,
+            @NonNull final UnsignedLong paymentRequestId
+    ) {
+        return new DestinationWithPaymentRequestMemoData(addressHash, numberOfRecipients, fee, totalOutlay, paymentRequestId);
+    }
+
+    private DestinationWithPaymentRequestMemoData(
+            @NonNull final AddressHash addressHash,
+            final int numberOfRecipients,
+            @NonNull final UnsignedLong fee,
+            @NonNull final UnsignedLong totalOutlay,
+            @NonNull final UnsignedLong paymentRequestId
+    ) {
+        super(addressHash);
+        this.numberOfRecipients = numberOfRecipients;
+        this.fee = fee;
+        this.totalOutlay = totalOutlay;
+        this.paymentRequestId = paymentRequestId;
+    }
+
+    // TODO: doc
+    public int getNumberOfRecipients() {
+        return numberOfRecipients;
+    }
+
+    // TODO: doc
+    @NonNull
+    public UnsignedLong getFee() {
+        return fee;
+    }
+
+    //TODO: doc
+    @NonNull
+    public UnsignedLong getTotalOutlay() {
+        return totalOutlay;
+    }
+
+    //TODO: doc
+    @NonNull
+    public UnsignedLong getPaymentRequestId() {
+        return paymentRequestId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DestinationWithPaymentRequestMemoData that = (DestinationWithPaymentRequestMemoData) o;
+        return numberOfRecipients == that.numberOfRecipients &&
+                Objects.equals(addressHash, that.addressHash) &&
+                Objects.equals(fee, that.fee) &&
+                Objects.equals(totalOutlay, that.totalOutlay) &&
+                Objects.equals(paymentRequestId, that.paymentRequestId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(addressHash, numberOfRecipients, fee, totalOutlay, paymentRequestId);
+    }
+
+    private DestinationWithPaymentRequestMemoData(@NonNull Parcel parcel) {
+        super(parcel.readParcelable(AddressHash.class.getClassLoader()));
+        fee = parcel.readParcelable(UnsignedLong.class.getClassLoader());
+        totalOutlay = parcel.readParcelable(UnsignedLong.class.getClassLoader());
+        numberOfRecipients = parcel.readInt();
+        paymentRequestId = parcel.readParcelable(UnsignedLong.class.getClassLoader());
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel parcel, int flags) {
+        super.writeToParcel(parcel, flags);
+        parcel.writeParcelable(fee, flags);
+        parcel.writeParcelable(totalOutlay, flags);
+        parcel.writeInt(numberOfRecipients);
+        parcel.writeParcelable(paymentRequestId, flags);
+    }
+
+    public static final Creator<DestinationWithPaymentRequestMemoData> CREATOR = new Creator<DestinationWithPaymentRequestMemoData>() {
+        @Override
+        public DestinationWithPaymentRequestMemoData createFromParcel(@NonNull Parcel parcel) {
+            return new DestinationWithPaymentRequestMemoData(parcel);
+        }
+
+        @Override
+        public DestinationWithPaymentRequestMemoData[] newArray(int length) {
+            return new DestinationWithPaymentRequestMemoData[length];
+        }
+    };
+
+}

--- a/android-sdk/src/main/java/com/mobilecoin/lib/EmptyMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/EmptyMemo.java
@@ -4,7 +4,7 @@ import android.os.Parcel;
 
 import androidx.annotation.NonNull;
 
-public class EmptyMemo extends TxOutMemo {
+public final class EmptyMemo extends TxOutMemo {
 
     public EmptyMemo(TxOutMemoType memoType) {
         super(memoType);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentIntentMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentIntentMemo.java
@@ -1,0 +1,134 @@
+package com.mobilecoin.lib;
+
+import android.os.Parcel;
+
+import androidx.annotation.NonNull;
+
+import com.mobilecoin.lib.exceptions.InvalidTxOutMemoException;
+
+import java.util.Objects;
+
+// TODO: doc
+public final class SenderWithPaymentIntentMemo extends TxOutMemo {
+
+    private static final String TAG = SenderWithPaymentIntentMemo.class.getSimpleName();
+
+    private final RistrettoPublic txOutPublicKey;
+    private final SenderWithPaymentIntentMemoData senderWithPaymentIntentMemoData;
+    /**
+     * Creates a {@link SenderWithPaymentIntentMemo} from a decrypted memo data that hasn't been
+     * validated yet.
+     *
+     * @param memoData - The {@value TxOutMemo#TX_OUT_MEMO_DATA_SIZE_BYTES} bytes that correspond to the memo payload.
+     **/
+    static SenderWithPaymentIntentMemo create(
+            @NonNull RistrettoPublic txOutPublicKey,
+            @NonNull byte[] memoData
+    ) {
+        if (memoData.length != TxOutMemo.TX_OUT_MEMO_DATA_SIZE_BYTES) {
+            throw new IllegalArgumentException("Memo data byte array must have a length of " +
+                    TxOutMemo.TX_OUT_MEMO_DATA_SIZE_BYTES + ". Instead, the length was: " + memoData.length);
+        }
+        return new SenderWithPaymentIntentMemo(txOutPublicKey, memoData);
+    }
+
+    private SenderWithPaymentIntentMemo(
+            @NonNull RistrettoPublic txOutPublicKey,
+            @NonNull byte[] memoData
+    ) {
+        super(TxOutMemoType.SENDER_WITH_PAYMENT_INTENT);
+        this.txOutPublicKey = txOutPublicKey;
+        try {
+            init_jni_from_memo_data(memoData);
+        } catch(Exception e) {
+            IllegalArgumentException illegalArgumentException =
+                    new IllegalArgumentException("Failed to create a SenderWithPaymentIntentMemo", e);
+            Util.logException(TAG, illegalArgumentException);
+            throw illegalArgumentException;
+        }
+        UnsignedLong paymentIntentId = UnsignedLong.fromLongBits(get_payment_intent_id());
+        senderWithPaymentIntentMemoData = SenderWithPaymentIntentMemoData.create(getAddressHash(), paymentIntentId);
+    }
+
+
+    // TODO: doc
+    public AddressHash getUnvalidatedAddressHash() {
+        return getAddressHash();
+    }
+
+    private AddressHash getAddressHash() {
+        byte[] addressHashData = get_address_hash_data();
+        return AddressHash.createAddressHash(addressHashData);
+    }
+
+    /**
+     * Validates then retrieves the sender with payment intent memo data.
+     *
+     * <p>Before calling this method, call {@link #getUnvalidatedAddressHash()} and see if the
+     * {@link AddressHash} corresponds to a {@link PublicAddress} that is known by the user.
+     * If the {@link PublicAddress} is not known by the user, then do not call this method because the
+     * memo is automatically invalid.
+     **/// TODO: doc
+    public SenderWithPaymentIntentMemoData getSenderWithPaymentIntentMemoData(
+            @NonNull PublicAddress senderPublicAddress,
+            @NonNull RistrettoPrivate receiverSubaddressViewKey) throws InvalidTxOutMemoException {
+        if(!validated) {
+            if (!(validated = is_valid(
+                    senderPublicAddress,
+                    receiverSubaddressViewKey,
+                    txOutPublicKey)
+            )) {
+                throw new InvalidTxOutMemoException("The sender memo is invalid.");
+            }
+        }
+        return senderWithPaymentIntentMemoData;
+    }
+
+    private SenderWithPaymentIntentMemo(@NonNull Parcel parcel) {
+        super(TxOutMemoType.SENDER_WITH_PAYMENT_INTENT);
+        txOutPublicKey = parcel.readParcelable(RistrettoPublic.class.getClassLoader());
+        senderWithPaymentIntentMemoData = parcel.readParcelable(SenderWithPaymentIntentMemoData.class.getClassLoader());
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel parcel, int flags) {
+        parcel.writeParcelable(txOutPublicKey, flags);
+        parcel.writeParcelable(senderWithPaymentIntentMemoData, flags);
+    }
+
+    public static Creator<SenderWithPaymentIntentMemo> CREATOR = new Creator<SenderWithPaymentIntentMemo>() {
+        @Override
+        public SenderWithPaymentIntentMemo createFromParcel(@NonNull Parcel parcel) {
+            return new SenderWithPaymentIntentMemo(parcel);
+        }
+
+        @Override
+        public SenderWithPaymentIntentMemo[] newArray(int length) {
+            return new SenderWithPaymentIntentMemo[length];
+        }
+    };
+
+    @Override
+    public boolean equals(Object o) {
+        if(o instanceof SenderWithPaymentIntentMemo) {
+            SenderWithPaymentIntentMemo that = (SenderWithPaymentIntentMemo)o;
+            return Objects.equals(this.memoType, that.memoType) &&
+                    Objects.equals(this.txOutPublicKey, that.txOutPublicKey) &&
+                    Objects.equals(this.senderWithPaymentIntentMemoData, that.senderWithPaymentIntentMemoData);
+        }
+        return false;
+    }
+
+    private native void init_jni_from_memo_data(byte[] memoData);
+
+    // Returns true if the sender with payment intent memo is valid.
+    private native boolean is_valid(
+            @NonNull PublicAddress senderPublicAddress,
+            @NonNull RistrettoPrivate receiverSubaddressViewKey,
+            @NonNull RistrettoPublic txOutPublicKey
+    );
+
+    private native byte[] get_address_hash_data();
+
+    private native long get_payment_intent_id();
+}

--- a/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentIntentMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentIntentMemo.java
@@ -8,7 +8,19 @@ import com.mobilecoin.lib.exceptions.InvalidTxOutMemoException;
 
 import java.util.Objects;
 
-// TODO: doc
+/**
+ * This class represents a {@link SenderMemo} tied to a specific <strong>payment intent</strong>.
+ *
+ * This should be interpreted the same as a {@link SenderMemo} but has one additional field, a <strong>payment intent</strong> ID.
+ * This memo is paired with a {@link DestinationWithPaymentIntentMemo} which the sender sends to themselves and contains the same <strong>payment intent</strong> ID.
+ *
+ * @see SenderMemo
+ * @see DestinationWithPaymentIntentMemo
+ * @see SenderWithPaymentIntentMemoData
+ * @see SenderWithPaymentIntentMemoData#getPaymentIntentId()
+ * @see TxOutMemo
+ * @since 2.0.0
+ */
 public final class SenderWithPaymentIntentMemo extends TxOutMemo {
 
     private static final String TAG = SenderWithPaymentIntentMemo.class.getSimpleName();
@@ -20,7 +32,7 @@ public final class SenderWithPaymentIntentMemo extends TxOutMemo {
      * validated yet.
      *
      * @param memoData - The {@value TxOutMemo#TX_OUT_MEMO_DATA_SIZE_BYTES} bytes that correspond to the memo payload.
-     **/
+     */
     static SenderWithPaymentIntentMemo create(
             @NonNull RistrettoPublic txOutPublicKey,
             @NonNull byte[] memoData
@@ -51,7 +63,25 @@ public final class SenderWithPaymentIntentMemo extends TxOutMemo {
     }
 
 
-    // TODO: doc
+    /**
+     * Returns the {@link AddressHash} stored in this {@link SenderWithPaymentIntentMemo} without validating it first.
+     *
+     * To get the validated {@link AddressHash}, use {@link SenderWithPaymentIntentMemoData#getAddressHash()}.
+     *
+     * It is recommended to compare the output of this method to {@link AddressHash}es of known {@link PublicAddress}.
+     * If the output of this method matches any known {@link PublicAddress} {@link AddressHash}, the memo
+     * can be validated using that {@link PublicAddress}.
+     *
+     * @return the {@link AddressHash} in this memo without validating it first
+     *
+     * @see AddressHash
+     * @see SenderWithPaymentIntentMemoData
+     * @see SenderWithPaymentIntentMemoData#getAddressHash()
+     * @see SenderWithPaymentIntentMemo#getSenderWithPaymentIntentMemoData(PublicAddress, RistrettoPrivate)
+     * @see SenderMemo
+     * @see SenderMemo#getUnvalidatedAddressHash()
+     * @since 2.0.0
+     */
     public AddressHash getUnvalidatedAddressHash() {
         return getAddressHash();
     }
@@ -62,13 +92,23 @@ public final class SenderWithPaymentIntentMemo extends TxOutMemo {
     }
 
     /**
-     * Validates then retrieves the sender with payment intent memo data.
+     * Returns the {@link SenderWithPaymentIntentMemoData} for this {@link SenderWithPaymentIntentMemo} if valid.
      *
-     * <p>Before calling this method, call {@link #getUnvalidatedAddressHash()} and see if the
+     * If validation of the memo fails, an {@link InvalidTxOutMemoException} is thrown
+     *
+     * Before calling this method, call {@link SenderWithPaymentIntentMemo#getUnvalidatedAddressHash()} and see if the
      * {@link AddressHash} corresponds to a {@link PublicAddress} that is known by the user.
      * If the {@link PublicAddress} is not known by the user, then do not call this method because the
      * memo is automatically invalid.
-     **/// TODO: doc
+     *
+     * @return the {@link SenderWithPaymentIntentMemoData}, if valid
+     * @throws InvalidTxOutMemoException if validation of the memo fails
+     *
+     * @see SenderWithPaymentIntentMemoData
+     * @see MemoData
+     * @see InvalidTxOutMemoException
+     * @since 2.0.0
+     */
     public SenderWithPaymentIntentMemoData getSenderWithPaymentIntentMemoData(
             @NonNull PublicAddress senderPublicAddress,
             @NonNull RistrettoPrivate receiverSubaddressViewKey) throws InvalidTxOutMemoException {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentIntentMemoData.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentIntentMemoData.java
@@ -1,0 +1,83 @@
+package com.mobilecoin.lib;
+
+import android.os.Parcel;
+
+import androidx.annotation.NonNull;
+
+import java.util.Objects;
+
+/**
+ * Contains data associated with a sender with payment intent memo.
+ *
+ * <p>The data has been validated, which means that we've verified that the correct sender
+ * wrote the memo and that the data has not been corrupted.
+ **///TODO: doc
+public final class SenderWithPaymentIntentMemoData extends MemoData {
+
+    @NonNull
+    private final UnsignedLong paymentIntentId;
+
+    /**
+     * Creates a {@link SenderWithPaymentIntentMemoData} instance with all of the expected fields.
+     * */// TODO: doc
+    public static SenderWithPaymentIntentMemoData create(
+            @NonNull AddressHash addressHash,
+            @NonNull UnsignedLong paymentIntentId
+    ) {
+        return new SenderWithPaymentIntentMemoData(addressHash, paymentIntentId);
+    }
+
+    private SenderWithPaymentIntentMemoData(@NonNull AddressHash addressHash, @NonNull UnsignedLong paymentIntentId) {
+        super(addressHash);
+        this.paymentIntentId = paymentIntentId;
+    }
+
+    //TODO: doc
+    @NonNull
+    public UnsignedLong getPaymentIntentId() {
+        return paymentIntentId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SenderWithPaymentIntentMemoData that = (SenderWithPaymentIntentMemoData) o;
+
+        return Objects.equals(addressHash, that.addressHash) &&
+                Objects.equals(paymentIntentId, that.paymentIntentId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(addressHash, paymentIntentId);
+    }
+
+    private SenderWithPaymentIntentMemoData(@NonNull Parcel parcel) {
+        super(parcel.readParcelable(AddressHash.class.getClassLoader()));
+        paymentIntentId = parcel.readParcelable(UnsignedLong.class.getClassLoader());
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel parcel, int flags) {
+        super.writeToParcel(parcel, flags);
+        parcel.writeParcelable(paymentIntentId, flags);
+    }
+
+    public static final Creator<SenderWithPaymentIntentMemoData> CREATOR = new Creator<SenderWithPaymentIntentMemoData>() {
+        @Override
+        public SenderWithPaymentIntentMemoData createFromParcel(@NonNull Parcel parcel) {
+            return new SenderWithPaymentIntentMemoData(parcel);
+        }
+
+        @Override
+        public SenderWithPaymentIntentMemoData[] newArray(int length) {
+            return new SenderWithPaymentIntentMemoData[length];
+        }
+    };
+
+}

--- a/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentIntentMemoData.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentIntentMemoData.java
@@ -7,11 +7,16 @@ import androidx.annotation.NonNull;
 import java.util.Objects;
 
 /**
- * Contains data associated with a sender with payment intent memo.
+ * Contains data associated with a {@link SenderWithPaymentIntentMemo}.
  *
- * <p>The data has been validated, which means that we've verified that the correct sender
- * wrote the memo and that the data has not been corrupted.
- **///TODO: doc
+ * The data has been validated, which means that the sender of the {@link SenderWithPaymentIntentMemo}
+ * has been verified and that the data has not been corrupted.
+ *
+ * @see SenderWithPaymentIntentMemo
+ * @see MemoData
+ * @see AddressHash
+ * @since 2.0.0
+ */
 public final class SenderWithPaymentIntentMemoData extends MemoData {
 
     @NonNull
@@ -19,8 +24,8 @@ public final class SenderWithPaymentIntentMemoData extends MemoData {
 
     /**
      * Creates a {@link SenderWithPaymentIntentMemoData} instance with all of the expected fields.
-     * */// TODO: doc
-    public static SenderWithPaymentIntentMemoData create(
+     */
+    static SenderWithPaymentIntentMemoData create(
             @NonNull AddressHash addressHash,
             @NonNull UnsignedLong paymentIntentId
     ) {
@@ -32,7 +37,19 @@ public final class SenderWithPaymentIntentMemoData extends MemoData {
         this.paymentIntentId = paymentIntentId;
     }
 
-    //TODO: doc
+    /**
+     * Gets the <strong>payment intent</strong> ID stored in this {@link SenderWithPaymentIntentMemoData}
+     *
+     * For additional information about this field, see
+     * {@link TxOutMemoBuilder#createSenderPaymentIntentAndDestinationRTHMemoBuilder(AccountKey, UnsignedLong)}.
+     *
+     * @return the ID of a <strong>payment intent</strong>
+     *
+     * @see TxOutMemoBuilder#createSenderPaymentIntentAndDestinationRTHMemoBuilder(AccountKey, UnsignedLong)
+     * @see SenderWithPaymentIntentMemo
+     * @see DestinationWithPaymentIntentMemoData#getPaymentIntentId()
+     * @since 2.0.0
+     */
     @NonNull
     public UnsignedLong getPaymentIntentId() {
         return paymentIntentId;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentRequestMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentRequestMemo.java
@@ -8,7 +8,19 @@ import com.mobilecoin.lib.exceptions.InvalidTxOutMemoException;
 
 import java.util.Objects;
 
-// TODO: doc
+/**
+ * This class represents a {@link SenderMemo} tied to a specific <strong>payment request</strong>.
+ *
+ * This should be interpreted the same as a {@link SenderMemo} but has one additional field, a <strong>payment request</strong> ID.
+ * This memo is paired with a {@link DestinationWithPaymentRequestMemo} which the sender sends to themselves and contains the same <strong>payment request</strong> ID.
+ *
+ * @see SenderMemo
+ * @see DestinationWithPaymentRequestMemo
+ * @see SenderWithPaymentRequestMemoData
+ * @see SenderWithPaymentRequestMemoData#getPaymentRequestId()
+ * @see TxOutMemo
+ * @since 1.2.0
+ */
 public final class SenderWithPaymentRequestMemo extends TxOutMemo {
 
   private static final String TAG = SenderWithPaymentRequestMemo.class.getSimpleName();
@@ -20,7 +32,7 @@ public final class SenderWithPaymentRequestMemo extends TxOutMemo {
    * validated yet.
    *
    * @param memoData - The {@value TxOutMemo#TX_OUT_MEMO_DATA_SIZE_BYTES} bytes that correspond to the memo payload.
-   **/
+   */
   static SenderWithPaymentRequestMemo create(
       @NonNull RistrettoPublic txOutPublicKey,
       @NonNull byte[] memoData
@@ -51,7 +63,25 @@ public final class SenderWithPaymentRequestMemo extends TxOutMemo {
   }
 
 
-  // TODO: doc
+  /**
+   * Returns the {@link AddressHash} stored in this {@link SenderWithPaymentRequestMemo} without validating it first.
+   *
+   * To get the validated {@link AddressHash}, use {@link SenderWithPaymentRequestMemoData#getAddressHash()}.
+   *
+   * It is recommended to compare the output of this method to {@link AddressHash}es of known {@link PublicAddress}.
+   * If the output of this method matches any known {@link PublicAddress} {@link AddressHash}, the memo
+   * can be validated using that {@link PublicAddress}.
+   *
+   * @return the {@link AddressHash} in this memo without validating it first
+   *
+   * @see AddressHash
+   * @see SenderWithPaymentRequestMemoData
+   * @see SenderWithPaymentRequestMemoData#getAddressHash()
+   * @see SenderWithPaymentRequestMemo#getSenderWithPaymentRequestMemoData(PublicAddress, RistrettoPrivate)
+   * @see SenderMemo
+   * @see SenderMemo#getUnvalidatedAddressHash()
+   * @since 1.2.0
+   */
   public AddressHash getUnvalidatedAddressHash() {
     return getAddressHash();
   }
@@ -62,13 +92,23 @@ public final class SenderWithPaymentRequestMemo extends TxOutMemo {
   }
 
   /**
-   * Validates then retrieves the sender with payment request memo data.
+   * Returns the {@link SenderWithPaymentRequestMemoData} for this {@link SenderWithPaymentRequestMemo} if valid.
    *
-   * <p>Before calling this method, call {@link #getUnvalidatedAddressHash()} and see if the
+   * If validation of the memo fails, an {@link InvalidTxOutMemoException} is thrown
+   *
+   * Before calling this method, call {@link SenderWithPaymentRequestMemo#getUnvalidatedAddressHash()} and see if the
    * {@link AddressHash} corresponds to a {@link PublicAddress} that is known by the user.
    * If the {@link PublicAddress} is not known by the user, then do not call this method because the
    * memo is automatically invalid.
-   **/// TODO: doc
+   *
+   * @return the {@link SenderWithPaymentRequestMemoData}, if valid
+   * @throws InvalidTxOutMemoException if validation of the memo fails
+   *
+   * @see SenderWithPaymentRequestMemoData
+   * @see MemoData
+   * @see InvalidTxOutMemoException
+   * @since 1.2.0
+   */
   public SenderWithPaymentRequestMemoData getSenderWithPaymentRequestMemoData(
       @NonNull PublicAddress senderPublicAddress,
       @NonNull RistrettoPrivate receiverSubaddressViewKey) throws InvalidTxOutMemoException {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentRequestMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentRequestMemo.java
@@ -8,10 +8,7 @@ import com.mobilecoin.lib.exceptions.InvalidTxOutMemoException;
 
 import java.util.Objects;
 
-/**
- * Represents a sender memo with a payment request id, which corresponds to the
- * "AuthenticatedSenderWithPaymentRequestIdMemo" specification.
- **/
+// TODO: doc
 public final class SenderWithPaymentRequestMemo extends TxOutMemo {
 
   private static final String TAG = SenderWithPaymentRequestMemo.class.getSimpleName();
@@ -54,11 +51,7 @@ public final class SenderWithPaymentRequestMemo extends TxOutMemo {
   }
 
 
-  /**
-   * Retrieves the {@link AddressHash} that hasn't been validated yet.
-   *
-   * <p>This is used to see if the user who wrote the sender memo is known by the current user.
-   * */
+  // TODO: doc
   public AddressHash getUnvalidatedAddressHash() {
     return getAddressHash();
   }
@@ -75,7 +68,7 @@ public final class SenderWithPaymentRequestMemo extends TxOutMemo {
    * {@link AddressHash} corresponds to a {@link PublicAddress} that is known by the user.
    * If the {@link PublicAddress} is not known by the user, then do not call this method because the
    * memo is automatically invalid.
-   **/
+   **/// TODO: doc
   public SenderWithPaymentRequestMemoData getSenderWithPaymentRequestMemoData(
       @NonNull PublicAddress senderPublicAddress,
       @NonNull RistrettoPrivate receiverSubaddressViewKey) throws InvalidTxOutMemoException {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentRequestMemoData.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentRequestMemoData.java
@@ -11,7 +11,7 @@ import java.util.Objects;
  *
  * <p>The data has been validated, which means that we've verified that the correct sender
  * wrote the memo and that the data has not been corrupted.
- **/
+ **///TODO: doc
 public final class SenderWithPaymentRequestMemoData extends MemoData {
 
   @NonNull
@@ -19,7 +19,7 @@ public final class SenderWithPaymentRequestMemoData extends MemoData {
 
   /**
    * Creates a {@link SenderWithPaymentRequestMemoData} instance with all of the expected fields.
-   * */
+   * */// TODO: doc
   public static SenderWithPaymentRequestMemoData create(
       @NonNull AddressHash addressHash,
       @NonNull UnsignedLong paymentRequestId
@@ -32,6 +32,7 @@ public final class SenderWithPaymentRequestMemoData extends MemoData {
     this.paymentRequestId = paymentRequestId;
   }
 
+  //TODO: doc
   @NonNull
   public UnsignedLong getPaymentRequestId() {
     return paymentRequestId;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentRequestMemoData.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentRequestMemoData.java
@@ -7,11 +7,16 @@ import androidx.annotation.NonNull;
 import java.util.Objects;
 
 /**
- * Contains data associated with a sender with payment request memo.
+ * Contains data associated with a {@link SenderWithPaymentRequestMemo}.
  *
- * <p>The data has been validated, which means that we've verified that the correct sender
- * wrote the memo and that the data has not been corrupted.
- **///TODO: doc
+ * The data has been validated, which means that the sender of the {@link SenderWithPaymentRequestMemo}
+ * has been verified and that the data has not been corrupted.
+ *
+ * @see SenderWithPaymentRequestMemo
+ * @see MemoData
+ * @see AddressHash
+ * @since 1.2.0
+ */
 public final class SenderWithPaymentRequestMemoData extends MemoData {
 
   @NonNull
@@ -19,8 +24,8 @@ public final class SenderWithPaymentRequestMemoData extends MemoData {
 
   /**
    * Creates a {@link SenderWithPaymentRequestMemoData} instance with all of the expected fields.
-   * */// TODO: doc
-  public static SenderWithPaymentRequestMemoData create(
+   */
+  static SenderWithPaymentRequestMemoData create(
       @NonNull AddressHash addressHash,
       @NonNull UnsignedLong paymentRequestId
   ) {
@@ -32,7 +37,19 @@ public final class SenderWithPaymentRequestMemoData extends MemoData {
     this.paymentRequestId = paymentRequestId;
   }
 
-  //TODO: doc
+  /**
+   * Gets the <strong>payment request</strong> ID stored in this {@link SenderWithPaymentRequestMemoData}
+   *
+   * For additional information about this field, see
+   * {@link TxOutMemoBuilder#createSenderPaymentRequestAndDestinationRTHMemoBuilder(AccountKey, UnsignedLong)}.
+   *
+   * @return the ID of a <strong>payment request</strong>
+   *
+   * @see TxOutMemoBuilder#createSenderPaymentRequestAndDestinationRTHMemoBuilder(AccountKey, UnsignedLong)
+   * @see SenderWithPaymentRequestMemo
+   * @see DestinationWithPaymentRequestMemoData#getPaymentRequestId()
+   * @since 1.2.0
+   */
   @NonNull
   public UnsignedLong getPaymentRequestId() {
     return paymentRequestId;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutMemoBuilder.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutMemoBuilder.java
@@ -24,16 +24,42 @@ public class TxOutMemoBuilder extends Native {
   }
 
   /**
-   * Creates an {@link TxOutMemoBuilder} with the sender with payment request id and destination
-   * RTH memos enabled.
+   * Creates a {@link TxOutMemoBuilder} that will build a {@link SenderWithPaymentRequestMemo} for a
+   * {@link Transaction} recipient and a {@link DestinationWithPaymentRequestMemo} for the sender.
+   *
+   * This field uniquely identifies a <strong>payment request</strong>. This ID is not guaranteed to be unique
+   * on the blockchain. Any value can be selected for this field. Clients should, however, select this field in such
+   * a way as to keep it unique at minimum for a pair of users. Whatever value is chosen, it should be agreed upon by
+   * both the sender and recipient outside of the blockchain in order to be useful.
+   *
+   * @see SenderWithPaymentRequestMemo
+   * @see SenderWithPaymentRequestMemoData
+   * @see SenderWithPaymentRequestMemoData#getPaymentRequestId()
+   * @see DestinationWithPaymentRequestMemo
+   * @see DestinationWithPaymentRequestMemoData
+   * @see DestinationWithPaymentRequestMemoData#getPaymentRequestId()
+   * @since 1.2.0
    **/
   public static TxOutMemoBuilder createSenderPaymentRequestAndDestinationRTHMemoBuilder(AccountKey accountKey, UnsignedLong paymentRequestId) throws TransactionBuilderException {
     return new TxOutMemoBuilder(accountKey, paymentRequestId, false);
   }
 
   /**
-   * Creates an {@link TxOutMemoBuilder} with the sender with payment intent id and destination
-   * RTH memos enabled.
+   * Creates a {@link TxOutMemoBuilder} that will build a {@link SenderWithPaymentIntentMemo} for a
+   * {@link Transaction} recipient and a {@link DestinationWithPaymentIntentMemo} for the sender.
+   *
+   * This field uniquely identifies a <strong>payment intent</strong>. This ID is not guaranteed to be unique
+   * on the blockchain. Any value can be selected for this field. Clients should, however, select this field in such
+   * a way as to keep it unique at minimum for a pair of users. Whatever value is chosen, it should be agreed upon by
+   * both the sender and recipient outside of the blockchain in order to be useful.
+   *
+   * @see SenderWithPaymentIntentMemo
+   * @see SenderWithPaymentIntentMemoData
+   * @see SenderWithPaymentIntentMemoData#getPaymentIntentId()
+   * @see DestinationWithPaymentIntentMemo
+   * @see DestinationWithPaymentIntentMemoData
+   * @see DestinationWithPaymentIntentMemoData#getPaymentIntentId()
+   * @since 2.0.0
    **/
   public static TxOutMemoBuilder createSenderPaymentIntentAndDestinationRTHMemoBuilder(AccountKey accountKey, UnsignedLong paymentIntentId) throws TransactionBuilderException {
     return new TxOutMemoBuilder(accountKey, paymentIntentId, true);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutMemoBuilder.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutMemoBuilder.java
@@ -28,7 +28,15 @@ public class TxOutMemoBuilder extends Native {
    * RTH memos enabled.
    **/
   public static TxOutMemoBuilder createSenderPaymentRequestAndDestinationRTHMemoBuilder(AccountKey accountKey, UnsignedLong paymentRequestId) throws TransactionBuilderException {
-    return new TxOutMemoBuilder(accountKey, paymentRequestId);
+    return new TxOutMemoBuilder(accountKey, paymentRequestId, false);
+  }
+
+  /**
+   * Creates an {@link TxOutMemoBuilder} with the sender with payment intent id and destination
+   * RTH memos enabled.
+   **/
+  public static TxOutMemoBuilder createSenderPaymentIntentAndDestinationRTHMemoBuilder(AccountKey accountKey, UnsignedLong paymentIntentId) throws TransactionBuilderException {
+    return new TxOutMemoBuilder(accountKey, paymentIntentId, true);
   }
 
    /**
@@ -39,12 +47,20 @@ public class TxOutMemoBuilder extends Native {
     return new TxOutMemoBuilder();
   }
 
-  private TxOutMemoBuilder(@NonNull AccountKey accountKey, UnsignedLong paymentRequestId) throws TransactionBuilderException {
+  private TxOutMemoBuilder(@NonNull AccountKey accountKey, UnsignedLong paymentId, boolean isPaymentIntent) throws TransactionBuilderException {
     try {
-      init_jni_with_sender_payment_request_and_destination_rth_memo(
-          accountKey,
-          paymentRequestId.longValue()
-      );
+      if(isPaymentIntent) {
+        init_jni_with_sender_payment_intent_and_destination_rth_memo(
+                accountKey,
+                paymentId.longValue()
+        );
+      }
+      else {
+        init_jni_with_sender_payment_request_and_destination_rth_memo(
+                accountKey,
+                paymentId.longValue()
+        );
+      }
     } catch (Exception exception) {
       throw new TransactionBuilderException("Unable to create TxOutMemoBuilder", exception);
     }
@@ -69,6 +85,8 @@ public class TxOutMemoBuilder extends Native {
   private native void init_jni_with_sender_and_destination_rth_memo(@NonNull AccountKey accountKey);
 
   private native void init_jni_with_sender_payment_request_and_destination_rth_memo(@NonNull AccountKey accountKey, long paymentRequestId);
+
+  private native void init_jni_with_sender_payment_intent_and_destination_rth_memo(@NonNull AccountKey accountKey, long paymentIntentId);
 
   private native void init_jni_with_default_rth_memo();
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutMemoParser.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutMemoParser.java
@@ -41,8 +41,17 @@ final class TxOutMemoParser {
             .create(nativeTxOut.getPublicKey(), memoData);
       case DESTINATION:
         return DestinationMemo.create(recipientAccountKey, nativeTxOut, memoData);
+      case DESTINATION_WITH_PAYMENT_REQUEST:
+        return DestinationWithPaymentRequestMemo
+            .create(recipientAccountKey, nativeTxOut, memoData);
+      case DESTINATION_WITH_PAYMENT_INTENT:
+        return DestinationWithPaymentIntentMemo
+            .create(recipientAccountKey, nativeTxOut, memoData);
       case SENDER_WITH_PAYMENT_REQUEST:
         return SenderWithPaymentRequestMemo
+            .create(nativeTxOut.getPublicKey(), memoData);
+      case SENDER_WITH_PAYMENT_INTENT:
+        return SenderWithPaymentIntentMemo
             .create(nativeTxOut.getPublicKey(), memoData);
       case UNKNOWN:
         return new EmptyMemo(TxOutMemoType.UNKNOWN);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutMemoType.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutMemoType.java
@@ -18,12 +18,26 @@ public enum TxOutMemoType implements Parcelable {
   NOT_SET(""),
   // Corresponds to the "UnusedMemo."
   UNUSED("0000"),
-  // Corresponds to the "AuthenticatedSenderMemo".
+  // Corresponds to the "BurnRedemptionMemo."
+  //BURN_REDEPMTION_MEMO("0001"),
+  // Corresponds to the "GiftCodeSenderMemo."
+  //GIFT_CODE_SENDER_MEMO("0002"),
+  // Corresponds to the "AuthenticatedSenderMemo."
   SENDER("0100"),
   // Corresponds to the "AuthenticatedSenderWithPaymentRequestIdMemo."
   SENDER_WITH_PAYMENT_REQUEST("0101"),
+  // Corresponds to the "AuthenticatedSenderWithPaymentIntentIdMemo."
+  SENDER_WITH_PAYMENT_INTENT("0102"),
   // Corresponds to the "DestinationMemo."
   DESTINATION("0200"),
+  // Corresponds to the "GiftCodeFundingMemo."
+  //GIFT_CODE_FUNDING_MEMO("0201"),
+  // Corresponds to the "GiftCodeCancellationMemo."
+  //GIFT_CODE_CANCELLATION_MEMO("0202"),
+  // Corresponds to the "DestinationWithPaymentRequestMemo."
+  DESTINATION_WITH_PAYMENT_REQUEST("0203"),
+  // Corresponds to the "DestinationWithPaymentIntentMemo."
+  DESTINATION_WITH_PAYMENT_INTENT("0204"),
   // Corresponds to when the sender wrote a memo type that isn't understood by the client yet.
   UNKNOWN("----");
 
@@ -39,22 +53,17 @@ public enum TxOutMemoType implements Parcelable {
     }
     else if (memoTypeBytes.length != TxOutMemo.TX_OUT_MEMO_TYPE_SIZE_BYTES) {
       throw new IllegalArgumentException("Memo type bytes should be of length " +
-              TxOutMemo.TX_OUT_MEMO_TYPE_SIZE_BYTES+ ". Was: " + memoTypeBytes.length);
+              TxOutMemo.TX_OUT_MEMO_TYPE_SIZE_BYTES + ". Was: " + memoTypeBytes.length);
     }
 
-    if (Arrays.equals(memoTypeBytes, UNUSED.memoTypeBytes)) {
-      return UNUSED;
+    for(TxOutMemoType memoType : TxOutMemoType.values()) {
+      if(Arrays.equals(memoTypeBytes, memoType.memoTypeBytes)) {
+        return memoType;
+      }
     }
-    if (Arrays.equals(memoTypeBytes, SENDER.memoTypeBytes)) {
-      return SENDER;
-    }
-    if (Arrays.equals(memoTypeBytes, DESTINATION.memoTypeBytes)) {
-      return DESTINATION;
-    }
-    if (Arrays.equals(memoTypeBytes, SENDER_WITH_PAYMENT_REQUEST.memoTypeBytes)) {
-      return SENDER_WITH_PAYMENT_REQUEST;
-    }
-    return UNKNOWN;
+
+    return TxOutMemoType.UNKNOWN;
+
   }
 
   @Override


### PR DESCRIPTION
### Motivation

#67 added SenderWithPaymentRequestMemo. This memo allows recipients of a Transaction to know whether or not a received TxOut corresponds to a payment request. There is currently no way for the user sending that Transaction to recover this information using RTH or any other data on the blockchain. This PR adds a new memo type: DestinationWithPaymentRequestMemo, which the user sends themselves via a change TxOut when sending a Transaction with a SenderWithPaymentRequestMemo.

This PR also adds Sender and DestinationWithPaymentIntentMemo. These memos are structured the same but differ in memo type. Having a distinct type for payment intent memos allows clients to implement a payment intent flow.

### In this PR
* DestinationWithPaymentRequestMemo with MemoData
* SenderWithPaymentIntentMemo with MemoData
* DestinationWithPaymentIntentMemo with MemoData
* Sender/Destination With Payment Intent MemoBuilders
