### PR TITLE
Fix Insecure Transport Using TLS

### DIFF
--- a/android-sdk/src/grpc/java/com/mobilecoin/lib/network/services/transport/grpc/GRPCTransport.java
+++ b/android-sdk/src/grpc/java/com/mobilecoin/lib/network/services/transport/grpc/GRPCTransport.java
@@ -42,16 +42,16 @@ public class GRPCTransport extends Transport {
                             uri.getUri().getHost(),
                             uri.getUri().getPort()
                     );
-            if (uri.isTlsEnabled()) {
-                managedChannelBuilder.useTransportSecurity();
-            } else {
-                managedChannelBuilder.usePlaintext();
-            }
             Set<X509Certificate> trustRoots = serviceConfiguration.getTrustRoots();
             if (trustRoots != null && trustRoots.size() > 0) {
                 KeyStore caKeyStore = getTrustRootsKeyStore(trustRoots);
                 SSLSocketFactory sslSocketFactory = getTrustedSSLSocketFactory(caKeyStore);
                 managedChannelBuilder.sslSocketFactory(sslSocketFactory);
+            }
+            if (uri.isTlsEnabled()) {
+                managedChannelBuilder.useTransportSecurity();
+            } else {
+                managedChannelBuilder.usePlaintext();
             }
             this.managedChannel = managedChannelBuilder.build();
         } catch (Exception ex) {

--- a/android-sdk/src/grpc/java/com/mobilecoin/lib/network/services/transport/grpc/GRPCTransport.java
+++ b/android-sdk/src/grpc/java/com/mobilecoin/lib/network/services/transport/grpc/GRPCTransport.java
@@ -42,13 +42,13 @@ public class GRPCTransport extends Transport {
                             uri.getUri().getHost(),
                             uri.getUri().getPort()
                     );
-            Set<X509Certificate> trustRoots = serviceConfiguration.getTrustRoots();
-            if (trustRoots != null && trustRoots.size() > 0) {
-                KeyStore caKeyStore = getTrustRootsKeyStore(trustRoots);
-                SSLSocketFactory sslSocketFactory = getTrustedSSLSocketFactory(caKeyStore);
-                managedChannelBuilder.sslSocketFactory(sslSocketFactory);
-            }
             if (uri.isTlsEnabled()) {
+                Set<X509Certificate> trustRoots = serviceConfiguration.getTrustRoots();
+                if (trustRoots != null && trustRoots.size() > 0) {
+                    KeyStore caKeyStore = getTrustRootsKeyStore(trustRoots);
+                    SSLSocketFactory sslSocketFactory = getTrustedSSLSocketFactory(caKeyStore);
+                    managedChannelBuilder.sslSocketFactory(sslSocketFactory);
+                }
                 managedChannelBuilder.useTransportSecurity();
             } else {
                 managedChannelBuilder.usePlaintext();


### PR DESCRIPTION
### Motivation

If an insecure protocol is specified in Fog or Consensus URI, TLS should not be used. When the SSL socket factory is set in the managed channel builder, the manager channel builder automatically enables TLS. This PR moves the secure/insecure protocol check after the SSL socket factory specification. This will prevent the manager channel from using TLS if an insecure protocol is specified in the URI.

### In this PR
* Fix using TLS when insecure protocol is specified by URI

