### PR TITLE
Unvalidated Sender Memo Data

### DIFF
--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '4.0.0-pre0'
+version '4.0.0-pre1'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/SenderMemoTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/SenderMemoTest.java
@@ -65,7 +65,7 @@ public class SenderMemoTest {
   }
 
   @Test
-  public void getUnvalidatedSenderWithPaymentRequestMemoData_returnsSenderWithPaymentRequestMemoData() {
+  public void getUnvalidatedSenderMemoData_returnsSenderMemoData() {
     SenderMemo senderMemo = SenderMemo.create(null, new byte[TxOutMemo.TX_OUT_MEMO_DATA_SIZE_BYTES]);
 
     senderMemo.getUnvalidatedSenderMemoData();

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/SenderMemoTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/SenderMemoTest.java
@@ -65,6 +65,13 @@ public class SenderMemoTest {
   }
 
   @Test
+  public void getUnvalidatedSenderWithPaymentRequestMemoData_returnsSenderWithPaymentRequestMemoData() {
+    SenderMemo senderMemo = SenderMemo.create(null, new byte[TxOutMemo.TX_OUT_MEMO_DATA_SIZE_BYTES]);
+
+    senderMemo.getUnvalidatedSenderMemoData();
+  }
+
+  @Test
   public void testParcelable() throws Exception {
     RistrettoPublic txOutPublicKey = createRistrettoPublic(txOutPublicKeyHexProtoBytes);
     byte[] memoData = Hex.toByteArray(validMemoDataHexBytes);

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/SenderWithPaymentRequestMemoTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/SenderWithPaymentRequestMemoTest.java
@@ -62,9 +62,16 @@ public class SenderWithPaymentRequestMemoTest {
 
   @Test
   public void getUnvalidatedAddressHash_returnsAddressHash() {
-    SenderMemo senderMemo = SenderMemo.create(null, new byte[TxOutMemo.TX_OUT_MEMO_DATA_SIZE_BYTES]);
+    SenderWithPaymentRequestMemo senderMemo = SenderWithPaymentRequestMemo.create(null, new byte[TxOutMemo.TX_OUT_MEMO_DATA_SIZE_BYTES]);
 
     senderMemo.getUnvalidatedAddressHash();
+  }
+
+  @Test
+  public void getUnvalidatedSenderWithPaymentRequestMemoData_returnsSenderWithPaymentRequestMemoData() {
+    SenderWithPaymentRequestMemo senderMemo = SenderWithPaymentRequestMemo.create(null, new byte[TxOutMemo.TX_OUT_MEMO_DATA_SIZE_BYTES]);
+
+    senderMemo.getUnvalidatedSenderWithPaymentRequestMemoData();
   }
 
   @Test

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemo.java
@@ -18,7 +18,7 @@ import java.util.Objects;
  * @see SenderWithPaymentIntentMemo
  * @see DestinationWithPaymentIntentMemoData
  * @see TxOutMemo
- * @since 2.0.0
+ * @since 4.0.0
  */
 public final class DestinationWithPaymentIntentMemo extends TxOutMemo {
 
@@ -79,7 +79,7 @@ public final class DestinationWithPaymentIntentMemo extends TxOutMemo {
      * @see DestinationWithPaymentIntentMemoData
      * @see MemoData
      * @see InvalidTxOutMemoException
-     * @since 2.0.0
+     * @since 4.0.0
      */
     public DestinationWithPaymentIntentMemoData getDestinationWithPaymentIntentMemoData() throws InvalidTxOutMemoException {
         if (!validated) {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemoData.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentIntentMemoData.java
@@ -15,7 +15,7 @@ import java.util.Objects;
  * @see DestinationWithPaymentIntentMemo
  * @see MemoData
  * @see AddressHash
- * @since 2.0.0
+ * @since 4.0.0
  */
 public final class DestinationWithPaymentIntentMemoData extends MemoData {
 
@@ -58,7 +58,7 @@ public final class DestinationWithPaymentIntentMemoData extends MemoData {
      * @return the number of recipients of the associated {@link Transaction}
      *
      * @see MobileCoinClient#prepareTransaction(PublicAddress, Amount, Amount, TxOutMemoBuilder)
-     * @since 2.0.0
+     * @since 4.0.0
      */
     public int getNumberOfRecipients() {
         return numberOfRecipients;
@@ -79,7 +79,7 @@ public final class DestinationWithPaymentIntentMemoData extends MemoData {
      * @see Amount
      * @see Amount#getTokenId()
      * @see OwnedTxOut#getTxOutMemo()
-     * @since 2.0.0
+     * @since 4.0.0
      */
     @NonNull
     public UnsignedLong getFee() {
@@ -102,7 +102,7 @@ public final class DestinationWithPaymentIntentMemoData extends MemoData {
      * @see Amount
      * @see Amount#getTokenId()
      * @see OwnedTxOut#getTxOutMemo()
-     * @since 2.0.0
+     * @since 4.0.0
      */
     @NonNull
     public UnsignedLong getTotalOutlay() {
@@ -120,7 +120,7 @@ public final class DestinationWithPaymentIntentMemoData extends MemoData {
      * @see TxOutMemoBuilder#createSenderPaymentIntentAndDestinationRTHMemoBuilder(AccountKey, UnsignedLong)
      * @see DestinationWithPaymentIntentMemo
      * @see SenderWithPaymentIntentMemoData#getPaymentIntentId()
-     * @since 2.0.0
+     * @since 4.0.0
      */
     @NonNull
     public UnsignedLong getPaymentIntentId() {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemo.java
@@ -18,7 +18,7 @@ import java.util.Objects;
  * @see SenderWithPaymentRequestMemo
  * @see DestinationWithPaymentRequestMemoData
  * @see TxOutMemo
- * @since 2.0.0
+ * @since 4.0.0
  */
 public final class DestinationWithPaymentRequestMemo extends TxOutMemo {
 
@@ -79,7 +79,7 @@ public final class DestinationWithPaymentRequestMemo extends TxOutMemo {
      * @see DestinationWithPaymentRequestMemoData
      * @see MemoData
      * @see InvalidTxOutMemoException
-     * @since 2.0.0
+     * @since 4.0.0
      */
     public DestinationWithPaymentRequestMemoData getDestinationWithPaymentRequestMemoData() throws InvalidTxOutMemoException {
         if (!validated) {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemoData.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/DestinationWithPaymentRequestMemoData.java
@@ -15,7 +15,7 @@ import java.util.Objects;
  * @see DestinationWithPaymentRequestMemo
  * @see MemoData
  * @see AddressHash
- * @since 2.0.0
+ * @since 4.0.0
  */
 public final class DestinationWithPaymentRequestMemoData extends MemoData {
 
@@ -58,7 +58,7 @@ public final class DestinationWithPaymentRequestMemoData extends MemoData {
      * @return the number of recipients of the associated {@link Transaction}
      *
      * @see MobileCoinClient#prepareTransaction(PublicAddress, Amount, Amount, TxOutMemoBuilder)
-     * @since 2.0.0
+     * @since 4.0.0
      */
     public int getNumberOfRecipients() {
         return numberOfRecipients;
@@ -79,7 +79,7 @@ public final class DestinationWithPaymentRequestMemoData extends MemoData {
      * @see Amount
      * @see Amount#getTokenId()
      * @see OwnedTxOut#getTxOutMemo()
-     * @since 2.0.0
+     * @since 4.0.0
      */
     @NonNull
     public UnsignedLong getFee() {
@@ -102,7 +102,7 @@ public final class DestinationWithPaymentRequestMemoData extends MemoData {
      * @see Amount
      * @see Amount#getTokenId()
      * @see OwnedTxOut#getTxOutMemo()
-     * @since 2.0.0
+     * @since 4.0.0
      */
     @NonNull
     public UnsignedLong getTotalOutlay() {
@@ -120,7 +120,7 @@ public final class DestinationWithPaymentRequestMemoData extends MemoData {
      * @see TxOutMemoBuilder#createSenderPaymentRequestAndDestinationRTHMemoBuilder(AccountKey, UnsignedLong)
      * @see DestinationWithPaymentRequestMemo
      * @see SenderWithPaymentRequestMemoData#getPaymentRequestId()
-     * @since 2.0.0
+     * @since 4.0.0
      */
     @NonNull
     public UnsignedLong getPaymentRequestId() {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/SenderMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/SenderMemo.java
@@ -86,6 +86,25 @@ public final class SenderMemo extends TxOutMemo {
     return senderMemoData;
   }
 
+  /**
+   * Returns the {@link SenderMemoData} for this {@link SenderMemo} without validating.
+   *
+   * There is no guarantee that the {@link AddressHash} in this memo was actually calculated from the
+   * sender's {@link PublicAddress}. To validate the sender's {@link AddressHash}, use
+   * {@link SenderMemo#getSenderMemoData(PublicAddress, RistrettoPrivate)}
+   *
+   * @return the {@link SenderMemoData}
+   *
+   * @see SenderMemoData
+   * @see MemoData
+   * @see PublicAddress
+   * @see AddressHash
+   * @since 4.0.0
+   */
+  public SenderMemoData getUnvalidatedSenderMemoData() {
+    return senderMemoData;
+  }
+
   private SenderMemo(@NonNull Parcel parcel) {
     super(TxOutMemoType.SENDER);
     txOutPublicKey = parcel.readParcelable(RistrettoPublic.class.getClassLoader());

--- a/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentIntentMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentIntentMemo.java
@@ -19,7 +19,7 @@ import java.util.Objects;
  * @see SenderWithPaymentIntentMemoData
  * @see SenderWithPaymentIntentMemoData#getPaymentIntentId()
  * @see TxOutMemo
- * @since 2.0.0
+ * @since 4.0.0
  */
 public final class SenderWithPaymentIntentMemo extends TxOutMemo {
 
@@ -80,7 +80,7 @@ public final class SenderWithPaymentIntentMemo extends TxOutMemo {
      * @see SenderWithPaymentIntentMemo#getSenderWithPaymentIntentMemoData(PublicAddress, RistrettoPrivate)
      * @see SenderMemo
      * @see SenderMemo#getUnvalidatedAddressHash()
-     * @since 2.0.0
+     * @since 4.0.0
      */
     public AddressHash getUnvalidatedAddressHash() {
         return getAddressHash();
@@ -106,8 +106,11 @@ public final class SenderWithPaymentIntentMemo extends TxOutMemo {
      *
      * @see SenderWithPaymentIntentMemoData
      * @see MemoData
+     * @see PublicAddress
+     * @see AddressHash
      * @see InvalidTxOutMemoException
-     * @since 2.0.0
+     * @see SenderWithPaymentIntentMemo#getUnvalidatedAddressHash()
+     * @since 4.0.0
      */
     public SenderWithPaymentIntentMemoData getSenderWithPaymentIntentMemoData(
             @NonNull PublicAddress senderPublicAddress,
@@ -121,6 +124,25 @@ public final class SenderWithPaymentIntentMemo extends TxOutMemo {
                 throw new InvalidTxOutMemoException("The sender memo is invalid.");
             }
         }
+        return senderWithPaymentIntentMemoData;
+    }
+
+    /**
+     * Returns the {@link SenderWithPaymentIntentMemoData} for this {@link SenderWithPaymentIntentMemo} without validating.
+     *
+     * There is no guarantee that the {@link AddressHash} in this memo was actually calculated from the
+     * sender's {@link PublicAddress}. To validate the sender's {@link AddressHash}, use
+     * {@link SenderWithPaymentIntentMemo#getSenderWithPaymentIntentMemoData(PublicAddress, RistrettoPrivate)}
+     *
+     * @return the {@link SenderWithPaymentIntentMemoData}
+     *
+     * @see SenderWithPaymentIntentMemoData
+     * @see MemoData
+     * @see PublicAddress
+     * @see AddressHash
+     * @since 4.0.0
+     */
+    public SenderWithPaymentIntentMemoData getUnvalidatedSenderWithPaymentIntentMemoData() {
         return senderWithPaymentIntentMemoData;
     }
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentRequestMemo.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/SenderWithPaymentRequestMemo.java
@@ -106,6 +106,9 @@ public final class SenderWithPaymentRequestMemo extends TxOutMemo {
    *
    * @see SenderWithPaymentRequestMemoData
    * @see MemoData
+   * @see PublicAddress
+   * @see AddressHash
+   * @see SenderWithPaymentRequestMemo#getUnvalidatedAddressHash()
    * @see InvalidTxOutMemoException
    * @since 1.2.0
    */
@@ -121,6 +124,25 @@ public final class SenderWithPaymentRequestMemo extends TxOutMemo {
         throw new InvalidTxOutMemoException("The sender memo is invalid.");
       }
     }
+    return senderWithPaymentRequestMemoData;
+  }
+
+  /**
+   * Returns the {@link SenderWithPaymentRequestMemoData} for this {@link SenderWithPaymentRequestMemo} without validating.
+   *
+   * There is no guarantee that the {@link AddressHash} in this memo was actually calculated from the
+   * sender's {@link PublicAddress}. To validate the sender's {@link AddressHash}, use
+   * {@link SenderWithPaymentRequestMemo#getSenderWithPaymentRequestMemoData(PublicAddress, RistrettoPrivate)}
+   *
+   * @return the {@link SenderWithPaymentRequestMemoData}
+   *
+   * @see SenderWithPaymentRequestMemoData
+   * @see MemoData
+   * @see PublicAddress
+   * @see AddressHash
+   * @since 4.0.0
+   */
+  public SenderWithPaymentRequestMemoData getUnvalidatedSenderWithPaymentRequestMemoData() {
     return senderWithPaymentRequestMemoData;
   }
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/SignedContingentInput.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/SignedContingentInput.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
  * @see MobileCoinTransactionClient#cancelSignedContingentInput(SignedContingentInput, Amount)
  * @see MobileCoinTransactionClient#prepareTransaction(SignedContingentInput, Amount)
  * @see MobileCoinTransactionClient#prepareTransaction(SignedContingentInput, Amount, Rng)
- * @since 1.3.0
+ * @since 4.0.0
  */
 public class SignedContingentInput extends Native implements Parcelable {
 
@@ -76,7 +76,7 @@ public class SignedContingentInput extends Native implements Parcelable {
      * @see MobileCoinTransactionClient#prepareTransaction(SignedContingentInput, Amount)
      * @see MobileCoinTransactionClient#estimateTotalFee(Amount)
      * @see Amount
-     * @since 1.3.0
+     * @since 4.0.0
      */
     @NonNull
     public Amount getRewardAmount() {
@@ -100,7 +100,7 @@ public class SignedContingentInput extends Native implements Parcelable {
      * @see MobileCoinTransactionClient#prepareTransaction(SignedContingentInput, Amount, Rng)
      * @see MobileCoinTransactionClient#prepareTransaction(SignedContingentInput, Amount)
      * @see Amount
-     * @since 1.3.0
+     * @since 4.0.0
      */
     @NonNull
     public Amount getRequiredAmount() {
@@ -120,7 +120,7 @@ public class SignedContingentInput extends Native implements Parcelable {
      * @throws SerializationException if an {@link Exception} is encountered during serialization
      * @see SignedContingentInput
      * @see SignedContingentInput#fromByteArray(byte[])
-     * @since 1.3.0
+     * @since 4.0.0
      */
     @NonNull
     public byte[] toByteArray() throws SerializationException {
@@ -142,7 +142,7 @@ public class SignedContingentInput extends Native implements Parcelable {
      * @throws SerializationException if the byte array does not represent a serialized {@link SignedContingentInput}
      * @see SignedContingentInput
      * @see SignedContingentInput#toByteArray()
-     * @since 1.3.0
+     * @since 4.0.0
      */
     @NonNull
     public static SignedContingentInput fromByteArray(@NonNull final byte[] serializedBytes) throws SerializationException {
@@ -158,7 +158,7 @@ public class SignedContingentInput extends Native implements Parcelable {
      * @return true if this {@link SignedContingentInput} is valid, false otherwise
      * @see MobileCoinTransactionClient#prepareTransaction(SignedContingentInput, Amount)
      * @see MobileCoinTransactionClient#prepareTransaction(SignedContingentInput, Amount, Rng rng)
-     * @since 1.3.0
+     * @since 4.0.0
      */
     public boolean isValid() {
         if(!is_valid()) return false;

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutMemoBuilder.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutMemoBuilder.java
@@ -59,7 +59,7 @@ public class TxOutMemoBuilder extends Native {
    * @see DestinationWithPaymentIntentMemo
    * @see DestinationWithPaymentIntentMemoData
    * @see DestinationWithPaymentIntentMemoData#getPaymentIntentId()
-   * @since 2.0.0
+   * @since 4.0.0
    **/
   public static TxOutMemoBuilder createSenderPaymentIntentAndDestinationRTHMemoBuilder(AccountKey accountKey, UnsignedLong paymentIntentId) throws TransactionBuilderException {
     return new TxOutMemoBuilder(accountKey, paymentIntentId, true);


### PR DESCRIPTION
### Motivation

Currently sender memo types cannot recover the memo data without providing the PublicAddress of the sender. This PR adds methods to return the memo data for Sender memo types without having to provide a PublicAddress for validation.

### In this PR
* SenderWithPaymentRequestMemoData.getUnvalidatedSenderWithPaymentRequestMemoData()
* SenderWithPaymentIntentMemoData.getUnvalidatedSenderWithPaymentIntentMemoData()
* SenderMemoData.getUnvalidatedSenderMemoData()
* Some version number changes

