### PR TITLE
Improve Account Creation API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run:
           name: make tests
           command: make tests
-          no_output_timeout: 30m
+          no_output_timeout: 45m
 
       - store_artifacts:
           path: android-sdk/build/reports

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/AccountTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/AccountTest.java
@@ -300,6 +300,23 @@ public class AccountTest {
         }
     }
 
+    @Test
+    public void testCreateAccountFromRandomMnemonic() throws Exception {
+        for(int i = 0; i < 100000; i++) {
+            Mnemonics.createRandomMnemonic();
+        }
+        for(int i = 0; i < 1000; i++) {
+            final String mnemonic = Mnemonics.createRandomMnemonic();
+            AccountKey.fromMnemonicPhrase(
+                    mnemonic,
+                    0,
+                    fogConfig.getFogUri(),
+                    "",
+                    fogConfig.getFogAuthoritySpki()
+            );
+        }
+    }
+
     /**
      * Contains data needed for Account tests.
      */

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AccountKey.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AccountKey.java
@@ -320,12 +320,9 @@ public class AccountKey extends Native implements Parcelable {
      * @param bip39Entropy     mnemonic entropy, see {@link Mnemonics#bip39EntropyFromMnemonic}.
      * @param accountIndex     account index to derive.
      *
-     * @deprecated Deprecated as of 4.0.0.1. Please use {@link AccountKey#fromMnemonicPhrase(String, int, Uri, String, byte[])}.
      * @see AccountKey#fromMnemonicPhrase(String, int, Uri, String, byte[])
      * @see Mnemonics#createRandomMnemonic()
      */
-    @VisibleForTesting
-    @Deprecated
     @NonNull
     public static AccountKey fromBip39Entropy(
             @NonNull byte[] bip39Entropy,

--- a/android-sdk/src/main/java/com/mobilecoin/lib/AccountKey.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AccountKey.java
@@ -8,6 +8,7 @@ import android.os.Parcelable;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -245,7 +246,13 @@ public class AccountKey extends Native implements Parcelable {
      *                         disambiguates which one to use when sending to this
      *                         account
      * @throws IllegalArgumentException if method parameters are invalid
+     *
+     * @deprecated Deprecated as of 4.0.0.1. Please use {@link AccountKey#fromMnemonicPhrase(String, int, Uri, String, byte[])}.
+     * @see AccountKey#fromMnemonicPhrase(String, int, Uri, String, byte[])
+     * @see Mnemonics#createRandomMnemonic()
      */
+    @VisibleForTesting
+    @Deprecated
     @NonNull
     public static AccountKey createNew(
             @NonNull Uri fogReportUri,
@@ -312,7 +319,13 @@ public class AccountKey extends Native implements Parcelable {
      *                         disambiguates which one to use when sending to this account.
      * @param bip39Entropy     mnemonic entropy, see {@link Mnemonics#bip39EntropyFromMnemonic}.
      * @param accountIndex     account index to derive.
+     *
+     * @deprecated Deprecated as of 4.0.0.1. Please use {@link AccountKey#fromMnemonicPhrase(String, int, Uri, String, byte[])}.
+     * @see AccountKey#fromMnemonicPhrase(String, int, Uri, String, byte[])
+     * @see Mnemonics#createRandomMnemonic()
      */
+    @VisibleForTesting
+    @Deprecated
     @NonNull
     public static AccountKey fromBip39Entropy(
             @NonNull byte[] bip39Entropy,

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Mnemonics.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Mnemonics.java
@@ -59,13 +59,9 @@ public final class Mnemonics extends Native {
     /**
      * Gives entropy from the supplied mnemonic.
      *
-     * @deprecated Deprecated as of 4.0.0.1. Please use mnemonic phrases to initialize {@link AccountKey}s
-     *
      * @see AccountKey#fromMnemonicPhrase(String, int, Uri, String, byte[])
      * @see Mnemonics#createRandomMnemonic()
      */
-    @VisibleForTesting
-    @Deprecated
     public static byte[] bip39EntropyFromMnemonic(String mnemonic) throws BadMnemonicException {
         Logger.i(TAG, "Getting entropy from mnemonic");
         try {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Mnemonics.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Mnemonics.java
@@ -2,14 +2,43 @@
 
 package com.mobilecoin.lib;
 
+import android.net.Uri;
+
+import androidx.annotation.VisibleForTesting;
+
 import com.mobilecoin.lib.exceptions.BadEntropyException;
 import com.mobilecoin.lib.exceptions.BadMnemonicException;
 import com.mobilecoin.lib.log.Logger;
+import com.mobilecoin.lib.network.TransportProtocol;
+
+import java.util.List;
 
 public final class Mnemonics extends Native {
     private final static String TAG = Mnemonics.class.getName();
 
     private Mnemonics() {
+    }
+
+    /**
+     * Uses a cryptographically secure RNG implementation to generate a new random mnemonic.
+     *
+     * This method should only be used the first time an account is created. After generating the mnemonic,
+     * it must be stored securely by the end-user and should never be shared with anybody. If the
+     * mnemonic is lost, there is no way to generate the same one again.
+     *
+     * Mnemonics returned by this method can be passed to {@link AccountKey#fromMnemonicPhrase(String, int, Uri, String, byte[])}
+     * to create an {@link AccountKey}.
+     *
+     * @return a unique, securely generated, random mnemonic phrase
+     *
+     * @see AccountKey#fromMnemonicPhrase(String, int, Uri, String, byte[])
+     * @see MobileCoinClient#MobileCoinClient(AccountKey, Uri, Uri, TransportProtocol)
+     * @see MobileCoinClient#MobileCoinClient(AccountKey, Uri, Uri, ClientConfig, TransportProtocol)
+     * @see MobileCoinClient#MobileCoinClient(AccountKey, Uri, List, ClientConfig, TransportProtocol)
+     * @since 4.0.0.1
+     */
+    public static String createRandomMnemonic() {
+        return entropy_to_mnemonic(DefaultRng.createInstance().nextBytes(32));
     }
 
     /**
@@ -29,7 +58,14 @@ public final class Mnemonics extends Native {
 
     /**
      * Gives entropy from the supplied mnemonic.
+     *
+     * @deprecated Deprecated as of 4.0.0.1. Please use mnemonic phrases to initialize {@link AccountKey}s
+     *
+     * @see AccountKey#fromMnemonicPhrase(String, int, Uri, String, byte[])
+     * @see Mnemonics#createRandomMnemonic()
      */
+    @VisibleForTesting
+    @Deprecated
     public static byte[] bip39EntropyFromMnemonic(String mnemonic) throws BadMnemonicException {
         Logger.i(TAG, "Getting entropy from mnemonic");
         try {
@@ -60,9 +96,9 @@ public final class Mnemonics extends Native {
     }
 
     // native methods
-    private static native String entropy_to_mnemonic(byte[] entropy) throws Exception;
+    private static native String entropy_to_mnemonic(byte[] entropy);
 
-    private static native byte[] entropy_from_mnemonic(String mnemonic) throws Exception;
+    private static native byte[] entropy_from_mnemonic(String mnemonic);
 
     private static native String words_by_prefix(String prefix);
 }


### PR DESCRIPTION
### Motivation

There are three ways `AccountKey`s can be created:
1. `AccountKey.createNew`
2. `AccountKey.fromBip39Entropy`
3. `AccountKey.fromMnemonicPhrase`

The first of these is somewhat problematic. When an `AccountKey` is created using `AccountKey.createNew`, the `AccountKey` is created randomly. It doesn't take any recovery info passed into the API. However, after the `AccountKey` has been created, the `RootIdentity` cannot be recovered from it. So no recovery information can be extracted from the newly created `AccountKey`. So, short of just serializing the keys and storing the bytes somewhere, **_there is no way to create the same_** `AccountKey` **_twice using this API method._** Furthermore, this strategy of serializing the `AccountKey` is prone to storing insecurely, as it is not easy for people to record or reproduce.

The second is a bit better, as the recovery information is passed into the API, meaning the API caller must have the info before calling `AccountKey.fromBip39Entropy` and has the opportunity to save it first. However, a Bip39 entropy is still difficult for people to work with.

The third method provides the best user experience while making it more clear to developers that `AccountKey` recovery information should be saved securely _before_ it is created. And to make the process of creating a mnemonic easier for developers, a new method (`Mnemonics.createRandomMnemonic`) was added to assist with making cryptographically secure, random mnemonics. The old method of doing this would have been to create a Bip39 entropy manually and then use `Mnemonics.fromBip39Entropy`. But this isn't obvious, requires more code than should be necessary, and leaves it up to developers to securely generate the random account.

### In this PR
* Deprecate `AccountKey.createNew`
* Created new method for creating random mnemonics

### Future Work
* In a later version, remove deprecation tags and mark deprecated methods package-private as they are still useful for SDK testing purposes
* Update developer docs/integration guide to reflect new account creation process
