### PR TITLE
Expose onetime keys

### DIFF
--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/MobileCoinClientTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/MobileCoinClientTest.java
@@ -57,6 +57,32 @@ public class MobileCoinClientTest {
             GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE);
 
     @Test
+    public void benchmarkPrepareTransaction() throws Exception {
+        final MobileCoinClient client = MobileCoinClientBuilder.newBuilder().build();
+        final Amount amount = Amount.ofMOB(BigInteger.TEN);
+        final Amount fee = Amount.ofMOB(BigInteger.ONE);
+        final PublicAddress recipient = TestKeysManager.getNextAccountKey().getPublicAddress();
+        long times[] = new long[100];
+        final Rng rng = ChaCha20Rng.fromSeed(new byte[ChaCha20Rng.SEED_SIZE_BYTES]);
+        final long startTime = System.nanoTime();
+        for(int i = 0; i < 100; i++) {
+            client.prepareTransaction(
+                    recipient,
+                    amount,
+                    fee,
+                    TxOutMemoBuilder.createDefaultRTHMemoBuilder(),
+                    rng
+            );
+            times[i] = System.nanoTime();
+        }
+        Logger.e("HERE!", "" + (times[0] - startTime) / 1000000);
+        for(int i = 1; i < 100; i++) {
+            Logger.e("HERE!", "" + (times[i] - times[i - 1]) / 1000000);
+        }
+        client.shutdown();
+    }
+
+    @Test
     public void mobile_coin_client_integration_test() throws Exception {
         final Amount amount = Amount.ofMOB(BigInteger.TEN);
 

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/MobileCoinClientTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/MobileCoinClientTest.java
@@ -57,32 +57,6 @@ public class MobileCoinClientTest {
             GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE);
 
     @Test
-    public void benchmarkPrepareTransaction() throws Exception {
-        final MobileCoinClient client = MobileCoinClientBuilder.newBuilder().build();
-        final Amount amount = Amount.ofMOB(BigInteger.TEN);
-        final Amount fee = Amount.ofMOB(BigInteger.ONE);
-        final PublicAddress recipient = TestKeysManager.getNextAccountKey().getPublicAddress();
-        long times[] = new long[100];
-        final Rng rng = ChaCha20Rng.fromSeed(new byte[ChaCha20Rng.SEED_SIZE_BYTES]);
-        final long startTime = System.nanoTime();
-        for(int i = 0; i < 100; i++) {
-            client.prepareTransaction(
-                    recipient,
-                    amount,
-                    fee,
-                    TxOutMemoBuilder.createDefaultRTHMemoBuilder(),
-                    rng
-            );
-            times[i] = System.nanoTime();
-        }
-        Logger.e("HERE!", "" + (times[0] - startTime) / 1000000);
-        for(int i = 1; i < 100; i++) {
-            Logger.e("HERE!", "" + (times[i] - times[i - 1]) / 1000000);
-        }
-        client.shutdown();
-    }
-
-    @Test
     public void mobile_coin_client_integration_test() throws Exception {
         final Amount amount = Amount.ofMOB(BigInteger.TEN);
 

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/OnetimeKeysTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/OnetimeKeysTest.java
@@ -1,0 +1,51 @@
+package com.mobilecoin.lib;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import com.mobilecoin.lib.log.Logger;
+
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+public class OnetimeKeysTest {
+
+    @Test
+    public void testTxOutPublicKeyGeneration() throws Exception {
+        final MobileCoinClient client = MobileCoinClientBuilder.newBuilder().build();
+        final PublicAddress recipient = TestKeysManager.getNextAccountKey().getPublicAddress();
+        final byte[] rngSeed = DefaultRng.createInstance().nextBytes(ChaCha20Rng.SEED_SIZE_BYTES);
+        final PendingTransaction tx = client.prepareTransaction(
+                recipient,
+                Amount.ofMOB(BigInteger.ZERO),
+                Amount.ofMOB(BigInteger.TEN),
+                TxOutMemoBuilder.createSenderAndDestinationRTHMemoBuilder(client.getAccountKey()),
+                ChaCha20Rng.fromSeed(rngSeed)
+        );
+        final RistrettoPublic txOutPublicKey = tx.getPayloadTxOutContext().getTxOutPublicKey();
+        final RistrettoPublic changePublicKey = tx.getChangeTxOutContext().getTxOutPublicKey();
+
+        final RistrettoPublic recipientSpendPublic = recipient.getSpendKey();
+        final RistrettoPublic senderSpendPublic = client.getAccountKey().getChangeSubAddressSpendKey().getPublicKey();
+        // prepareTransaction uses the RNG we pass to generate a seed which TxBuilder uses to create a dedicated output RNG
+        final ChaCha20Rng outputRng = ChaCha20Rng.fromSeed(ChaCha20Rng.fromSeed(rngSeed).nextBytes(ChaCha20Rng.SEED_SIZE_BYTES));
+
+        outputRng.setWordPos(BigInteger.valueOf(16L));
+        final RistrettoPrivate txOutPrivateKey = RistrettoPrivate.fromRandom(outputRng);
+
+        outputRng.setWordPos(BigInteger.valueOf(48L));
+        final RistrettoPrivate changePrivateKey = RistrettoPrivate.fromRandom(outputRng);
+
+        final RistrettoPublic generatedTxOutPublicKey = OnetimeKeys.createTxOutPublicKey(txOutPrivateKey, recipientSpendPublic);
+        final RistrettoPublic generatedChangePublicKey = OnetimeKeys.createTxOutPublicKey(changePrivateKey, senderSpendPublic);
+
+        assertEquals(txOutPublicKey, generatedTxOutPublicKey);
+        assertEquals(changePublicKey, generatedChangePublicKey);
+        assertArrayEquals(txOutPublicKey.getKeyBytes(), generatedTxOutPublicKey.getKeyBytes());
+        assertArrayEquals(changePublicKey.getKeyBytes(), generatedChangePublicKey.getKeyBytes());
+
+    }
+
+}

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/OwnedTxOutTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/OwnedTxOutTest.java
@@ -200,7 +200,7 @@ public class OwnedTxOutTest {
 
     // Test valid with commitment
     RistrettoPublic txOutSharedSecret =
-            Util.getSharedSecret(receiverAccountKey.getViewKey(), txOutFromCrc32.getPublicKey());
+            OnetimeKeys.getSharedSecret(receiverAccountKey.getViewKey(), txOutFromCrc32.getPublicKey());
     byte validCommitmentData[] = new MaskedAmountV1(
             txOutSharedSecret,
             recordWithCrc32.getTxOutAmountMaskedValue(),

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/TxOutMemoIntegrationTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/TxOutMemoIntegrationTest.java
@@ -86,7 +86,7 @@ public class TxOutMemoIntegrationTest {
             fee
     );
 
-    RistrettoPrivate onetimePrivateKey = Util.recoverOnetimePrivateKey(
+    RistrettoPrivate onetimePrivateKey = OnetimeKeys.recoverOnetimePrivateKey(
         realTxOut.getPublicKey(),
         realTxOut.getTargetKey(),
         senderAccountKey
@@ -145,7 +145,7 @@ public class TxOutMemoIntegrationTest {
 
     TxOut realTxOut = txOuts.get(realIndex);
 
-    RistrettoPrivate onetimePrivateKey = Util.recoverOnetimePrivateKey(
+    RistrettoPrivate onetimePrivateKey = OnetimeKeys.recoverOnetimePrivateKey(
         realTxOut.getPublicKey(),
         realTxOut.getTargetKey(),
         senderAccountKey
@@ -207,7 +207,7 @@ public class TxOutMemoIntegrationTest {
             fee
           );
 
-    RistrettoPrivate onetimePrivateKey = Util.recoverOnetimePrivateKey(
+    RistrettoPrivate onetimePrivateKey = OnetimeKeys.recoverOnetimePrivateKey(
         realTxOut.getPublicKey(),
         realTxOut.getTargetKey(),
         senderAccountKey
@@ -287,7 +287,7 @@ public class TxOutMemoIntegrationTest {
             fee
     );
 
-    RistrettoPrivate onetimePrivateKey = Util.recoverOnetimePrivateKey(
+    RistrettoPrivate onetimePrivateKey = OnetimeKeys.recoverOnetimePrivateKey(
             realTxOut.getPublicKey(),
             realTxOut.getTargetKey(),
             senderAccountKey
@@ -366,7 +366,7 @@ public class TxOutMemoIntegrationTest {
             fee
     );
 
-    RistrettoPrivate onetimePrivateKey = Util.recoverOnetimePrivateKey(
+    RistrettoPrivate onetimePrivateKey = OnetimeKeys.recoverOnetimePrivateKey(
             realTxOut.getPublicKey(),
             realTxOut.getTargetKey(),
             senderAccountKey

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -403,7 +403,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         ).get(0);
         FogReportResponses reportsResponse = fogReportsManager.fetchReports(reportUris,
                 tombstoneBlockIndex, clientConfig.report);
-        RistrettoPrivate onetimePrivateKey = Util.recoverOnetimePrivateKey(
+        RistrettoPrivate onetimePrivateKey = OnetimeKeys.recoverOnetimePrivateKey(
                 txOutToSpend.getPublicKey(),
                 txOutToSpend.getTargetKey(),
                 accountKey
@@ -601,7 +601,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
                 DefaultRng.createInstance()
         ).get(0);
 
-        RistrettoPrivate onetimePrivateKey = Util.recoverOnetimePrivateKey(
+        RistrettoPrivate onetimePrivateKey = OnetimeKeys.recoverOnetimePrivateKey(
                 selected.getPublicKey(),
                 selected.getTargetKey(),
                 getAccountKey()
@@ -845,7 +845,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
             OwnedTxOut utxo = ring.utxo;
             totalAmount = totalAmount.add(utxo.getAmount());
 
-            RistrettoPrivate onetimePrivateKey = Util.recoverOnetimePrivateKey(
+            RistrettoPrivate onetimePrivateKey = OnetimeKeys.recoverOnetimePrivateKey(
                     utxo.getPublicKey(),
                     utxo.getTargetKey(),
                     accountKey

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OnetimeKeys.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OnetimeKeys.java
@@ -1,0 +1,67 @@
+package com.mobilecoin.lib;
+
+import androidx.annotation.NonNull;
+
+import com.mobilecoin.lib.exceptions.TransactionBuilderException;
+import com.mobilecoin.lib.log.Logger;
+
+public class OnetimeKeys extends Native {
+
+    private static final String TAG = OnetimeKeys.class.getName();
+
+    public static RistrettoPrivate recoverOnetimePrivateKey(
+            @NonNull final RistrettoPublic tx_pub_key,
+            @NonNull final RistrettoPublic tx_target_key,
+            @NonNull final AccountKey account_key
+    ) throws TransactionBuilderException {
+        Logger.i(TAG, "Recovering onetime private key", null, "tx_pub_key:", tx_pub_key);
+        try {
+            long rustObj = recover_onetime_private_key(
+                    tx_pub_key,
+                    tx_target_key,
+                    account_key
+            );
+            return RistrettoPrivate.fromJNI(rustObj);
+        } catch (Exception ex) {
+            throw new TransactionBuilderException(ex.getLocalizedMessage(), ex);
+        }
+    }
+
+    @NonNull
+    public static RistrettoPublic getSharedSecret(
+        @NonNull final RistrettoPrivate viewPrivateKey,
+        @NonNull final RistrettoPublic txOutPublicKey
+    ) throws TransactionBuilderException {
+      Logger.i(TAG, "Retrieving shared secret", null, "txOut public:", txOutPublicKey);
+      try {
+        long rustObj = get_shared_secret(viewPrivateKey, txOutPublicKey);
+        return RistrettoPublic.fromJNI(rustObj);
+      } catch(Exception ex) {
+        throw new TransactionBuilderException(ex.getLocalizedMessage(), ex);
+      }
+    }
+
+    @NonNull
+    public static RistrettoPublic createTxOutPublicKey(
+            @NonNull final RistrettoPrivate txOutPrivateKey,
+            @NonNull final RistrettoPublic recipientSpendPublicKey
+    ) {
+        return RistrettoPublic.fromJNI(create_tx_out_public_key(txOutPrivateKey, recipientSpendPublicKey));
+    }
+
+    private static native long recover_onetime_private_key(
+            @NonNull final RistrettoPublic tx_pub_key,
+            @NonNull final RistrettoPublic tx_target_key,
+            @NonNull final AccountKey account_key
+    );
+
+    private static native long get_shared_secret(
+        @NonNull final RistrettoPrivate viewPrivateKey,
+        @NonNull final RistrettoPublic txOutPublicKey
+    );
+
+    private static native long create_tx_out_public_key(
+            @NonNull final RistrettoPrivate tx_out_private_key,
+            @NonNull final RistrettoPublic recipient_spend_key
+    );
+}

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
@@ -78,7 +78,7 @@ public class OwnedTxOut implements Parcelable {
                             .setData(txOutRecord.getTxOutTargetKeyData())
                             .build();
             txOutTargetKey = RistrettoPublic.fromProtoBufObject(txOutTargetKeyProto);
-            RistrettoPublic txOutSharedSecret = Util.getSharedSecret(accountKey.getViewKey(), txOutPublicKey);
+            RistrettoPublic txOutSharedSecret = OnetimeKeys.getSharedSecret(accountKey.getViewKey(), txOutPublicKey);
             long maskedValue = txOutRecord.getTxOutAmountMaskedValue();
             final MaskedAmount maskedAmount = txOutRecord.hasTxOutAmountMaskedV2TokenId() ?
                     new MaskedAmountV2(txOutSharedSecret, maskedValue, txOutRecord.getTxOutAmountMaskedV2TokenId().toByteArray()) :
@@ -227,7 +227,7 @@ public class OwnedTxOut implements Parcelable {
 
     @NonNull
     public RistrettoPublic getSharedSecret(AccountKey accountKey) throws TransactionBuilderException {
-        return Util.getSharedSecret(accountKey.getViewKey(), txOutPublicKey);
+        return OnetimeKeys.getSharedSecret(accountKey.getViewKey(), txOutPublicKey);
     }
 
     public synchronized boolean isSpent(@NonNull UnsignedLong atIndex) {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/RistrettoPrivate.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/RistrettoPrivate.java
@@ -47,6 +47,11 @@ public final class RistrettoPrivate extends Native implements Parcelable {
         }
     }
 
+    private RistrettoPrivate(@NonNull final ChaCha20Rng rng) {
+        init_jni_from_random(rng);
+        keyBytes = getKeyBytes();
+    }
+
     /**
      * Create a RistrettoPrivate key instance from the key bytes
      *
@@ -59,6 +64,11 @@ public final class RistrettoPrivate extends Native implements Parcelable {
                 bytes,
                 PayloadType.KEY_BYTES
         );
+    }
+
+    @NonNull
+    public static RistrettoPrivate fromRandom(@NonNull final ChaCha20Rng rng) {
+        return new RistrettoPrivate(rng);
     }
 
     /**
@@ -177,6 +187,8 @@ public final class RistrettoPrivate extends Native implements Parcelable {
     private native void init_jni(@NonNull byte[] rawKeyBytes);
 
     private native void init_jni_seed(@NonNull byte[] seedBytes);
+
+    private native void init_jni_from_random(@NonNull final ChaCha20Rng rng);
 
     private native void finalize_jni();
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/Util.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/Util.java
@@ -4,7 +4,6 @@ package com.mobilecoin.lib;
 
 import androidx.annotation.NonNull;
 
-import com.mobilecoin.lib.exceptions.TransactionBuilderException;
 import com.mobilecoin.lib.log.Logger;
 
 import java.io.ByteArrayInputStream;
@@ -20,54 +19,11 @@ import java.util.Set;
 final class Util extends Native {
     private final static String TAG = Util.class.getName();
 
-    static RistrettoPrivate recoverOnetimePrivateKey(
-            @NonNull RistrettoPublic tx_pub_key,
-            @NonNull RistrettoPublic tx_target_key,
-            @NonNull AccountKey account_key
-    ) throws TransactionBuilderException {
-        Logger.i(TAG, "Recovering onetime private key", null, "tx_pub_key:", tx_pub_key);
-        try {
-            long rustObj = recover_onetime_private_key(
-                    tx_pub_key,
-                    tx_target_key,
-                    account_key
-            );
-            return RistrettoPrivate.fromJNI(rustObj);
-        } catch (Exception ex) {
-            throw new TransactionBuilderException(ex.getLocalizedMessage(), ex);
-        }
-    }
-
-    @NonNull
-    public static RistrettoPublic getSharedSecret(
-        @NonNull RistrettoPrivate viewPrivateKey,
-        @NonNull RistrettoPublic txOutPublicKey
-    ) throws TransactionBuilderException {
-      Logger.i(TAG, "Retrieving shared secret", null, "txOut public:", txOutPublicKey);
-      try {
-        long rustObj = get_shared_secret(viewPrivateKey, txOutPublicKey);
-        return RistrettoPublic.fromJNI(rustObj);
-      } catch(Exception ex) {
-        throw new TransactionBuilderException(ex.getLocalizedMessage(), ex);
-      }
-    }
-
     // Used in tests
     public native static String bigint2string(@NonNull BigInteger value);
 
-    private native static long recover_onetime_private_key(
-            @NonNull RistrettoPublic tx_pub_key,
-            @NonNull RistrettoPublic tx_target_key,
-            @NonNull AccountKey account_key
-    );
-
     @NonNull
     private native static byte[] attest_verify_report(@NonNull byte[] report);
-
-    private native static long get_shared_secret(
-        @NonNull RistrettoPrivate viewPrivateKey,
-        @NonNull RistrettoPublic txOutPublicKey
-    );
 
     static void logException(@NonNull String TAG, @NonNull Exception exception) {
         String message = exception.getMessage();

--- a/android-sdk/versions.gradle
+++ b/android-sdk/versions.gradle
@@ -28,7 +28,7 @@ versions.network = network_versions
 
 // JNI
 def jni_versions = [:]
-jni_versions.mobilecoin = '4.1.1-pre1'
+jni_versions.mobilecoin = '4.1.1'
 versions.jni = jni_versions
 
 // Testing

--- a/android-sdk/versions.gradle
+++ b/android-sdk/versions.gradle
@@ -28,7 +28,7 @@ versions.network = network_versions
 
 // JNI
 def jni_versions = [:]
-jni_versions.mobilecoin = '4.1.0'
+jni_versions.mobilecoin = '4.1.1-pre1'
 versions.jni = jni_versions
 
 // Testing


### PR DESCRIPTION
### Motivation

This PR refactors some onetime_keys functions from Util to a new class OnetimeKeys. Additionally, a new method was added and the class is exposed to the public API.

### In this PR
* Added `OnetimeKeys` class
* Moved `Util.recoverOnetimePrivateKey` to `OnetimeKeys`
* Moved `Util.getSharedSecret` to `OnetimeKeys`
* Added `createTxOutPublicKey` to `OnetimeKeys`
* Added test for `OnetimeKeys.createTxOutPublicKey`
* Added `RistrettoPrivate.fromRandom`

