### PR TITLE
Fog Seed Order Fix

### DIFF
--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '5.0.0'
+version '5.0.1-pre0'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
@@ -221,7 +221,7 @@ class FogSeed implements Parcelable, Comparable<FogSeed> {
         parcel.writeByteArray(nonce);
         parcel.writeInt(rngVersion);
         parcel.writeByte((byte) (isObsolete ? 1 : 0));
-        parcel.writeParcelable(ingestInvocationId, flags);
+        parcel.writeLong(ingestInvocationId.longValue());
         parcel.writeParcelable(startBlock, flags);
         parcel.writeTypedList(utxos);
     }
@@ -235,7 +235,7 @@ class FogSeed implements Parcelable, Comparable<FogSeed> {
         nonce = parcel.createByteArray();
         rngVersion = parcel.readInt();
         isObsolete = parcel.readByte() != 0;
-        ingestInvocationId = parcel.readParcelable(UnsignedLong.class.getClassLoader());
+        ingestInvocationId = UnsignedLong.fromLongBits(parcel.readLong());
         startBlock = parcel.readParcelable(UnsignedLong.class.getClassLoader());
         utxos = parcel.createTypedArrayList(OwnedTxOut.CREATOR);
     }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
@@ -134,43 +134,6 @@ class FogSeed implements Parcelable, Comparable<FogSeed> {
         isObsolete = true;
     }
 
-
-    private void writeObject(ObjectOutputStream out) throws IOException, KexRngException {
-        out.write(nonce.length);
-        out.write(nonce);
-
-        byte[] storedRngProtobufBytes = kexRng.getProtobufBytes();
-        out.write(storedRngProtobufBytes.length);
-        out.write(storedRngProtobufBytes);
-
-        out.writeInt(rngVersion);
-        out.writeObject(startBlock);
-        out.writeObject(utxos);
-        out.writeObject(ingestInvocationId);
-    }
-
-    @SuppressWarnings("unchecked")
-    private void readObject(ObjectInputStream in)
-        throws IOException, ClassNotFoundException, KexRngException {
-        int nonceLength = in.read();
-        nonce = new byte[nonceLength];
-        int bytesRead = in.read(nonce);
-        if (bytesRead != nonceLength) {
-            throw new IOException();
-        }
-        int storedRngProtobufBytesLength = in.read();
-        byte[] storedRngProtobufBytes = new byte[storedRngProtobufBytesLength];
-        int kexRngProtobufBytesRead = in.read(storedRngProtobufBytes);
-        if (kexRngProtobufBytesRead != storedRngProtobufBytesLength) {
-            throw new IOException();
-        }
-        kexRng = new ClientKexRng(storedRngProtobufBytes);
-        rngVersion = in.readInt();
-        startBlock = (UnsignedLong) in.readObject();
-        utxos = (ArrayList<OwnedTxOut>) in.readObject();
-        ingestInvocationId = (UnsignedLong) in.readObject();
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/FogSeed.java
@@ -262,6 +262,6 @@ class FogSeed implements Parcelable, Comparable<FogSeed> {
 
     @Override
     public int compareTo(FogSeed fogSeed) {
-        return this.startBlock.compareTo(fogSeed.startBlock);
+        return (int)(this.ingestInvocationId - fogSeed.ingestInvocationId);
     }
 }


### PR DESCRIPTION
### Motivation

This PR changes the way `FogSeed`s are ordered. Instead of using the start block, the ingest invocation ID is now used. To ensure sign-safe comparison, `ingestInvocationId`'s type has been changed to `UnsignedLong`. Serialization of `FogSeed`s is not affected by this change.

### In this PR
* Order `FogSeed`s by `ingestInvocationId` instead of `startBlock`
