### PR TITLE
Migrate Dependencies to AndroidX

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -146,8 +146,6 @@ publish.mustRunAfter(javadocJar)
 publish.mustRunAfter(sourceJar)
 
 dependencies {
-    // multidex to avoid 64K reference limit
-    implementation deps.android.multidex
     // @Nullable, @NonNull annotations
     implementation deps.android.annotation
     implementation deps.android.java_annotation
@@ -174,7 +172,6 @@ dependencies {
     androidTestImplementation deps.testing.runner
     androidTestImplementation deps.testing.rules
     androidTestImplementation deps.testing.espresso_core
-    androidTestImplementation deps.testing.support_rules
     androidTestImplementation deps.testing.okhttp3
 
 }

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -146,6 +146,8 @@ publish.mustRunAfter(javadocJar)
 publish.mustRunAfter(sourceJar)
 
 dependencies {
+    // multidex to avoid 64K reference limit
+    implementation deps.android.multidex
     // @Nullable, @NonNull annotations
     implementation deps.android.annotation
     implementation deps.android.java_annotation

--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '6.0.0'
+version '6.0.1-pre1'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '6.0.1-pre1'
+version '6.0.0'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-sdk/versions.gradle
+++ b/android-sdk/versions.gradle
@@ -7,7 +7,7 @@ versions.gradle_plugin = '7.1.3'
 versions.protobuf_gradle_plugin = '0.8.16'
 
 def build_versions = [:]
-build_versions.min_sdk = 21
+build_versions.min_sdk = 19
 build_versions.compile_sdk = 30
 build_versions.target_sdk = 33
 ext.build_versions = build_versions
@@ -16,6 +16,7 @@ ext.build_versions = build_versions
 def android_versions = [:]
 android_versions.desugar = '1.1.5'
 android_versions.annotation = '1.5.0'
+android_versions.multidex = "2.0.1"
 android_versions.javax_annotation = '1.3.2'
 versions.android = android_versions
 
@@ -46,6 +47,7 @@ deps.protobuf_gradle_plugin = "com.google.protobuf:protobuf-gradle-plugin:$versi
 
 def android_deps = [:]
 android_deps.annotation = "androidx.annotation:annotation:$versions.android.annotation"
+android_deps.multidex = "androidx.multidex:multidex:$versions.android.multidex"
 android_deps.java_annotation = "javax.annotation:javax.annotation-api:$versions.android.javax_annotation"
 android_deps.desugar = "com.android.tools:desugar_jdk_libs:$versions.android.desugar"
 deps.android = android_deps

--- a/android-sdk/versions.gradle
+++ b/android-sdk/versions.gradle
@@ -7,14 +7,13 @@ versions.gradle_plugin = '7.1.3'
 versions.protobuf_gradle_plugin = '0.8.16'
 
 def build_versions = [:]
-build_versions.min_sdk = 19
+build_versions.min_sdk = 21
 build_versions.compile_sdk = 30
-build_versions.target_sdk = 30
+build_versions.target_sdk = 33
 ext.build_versions = build_versions
 
 // Android
 def android_versions = [:]
-android_versions.multidex = '2.0.1'
 android_versions.desugar = '1.1.5'
 android_versions.annotation = '1.5.0'
 android_versions.javax_annotation = '1.3.2'
@@ -38,7 +37,6 @@ testing_versions.mockito = '5.2.0'
 testing_versions.core = '1.5.0'
 testing_versions.ext_junit = '1.1.5'
 testing_versions.espresso_core = '3.5.1'
-testing_versions.support_rules = '1.0.2'
 testing_versions.okhttp3 = '4.10.0'
 testing_versions.robolectric = '4.8'
 versions.testing = testing_versions
@@ -47,7 +45,6 @@ deps.gradle_plugin = "com.android.tools.build:gradle:$versions.gradle_plugin"
 deps.protobuf_gradle_plugin = "com.google.protobuf:protobuf-gradle-plugin:$versions.protobuf_gradle_plugin"
 
 def android_deps = [:]
-android_deps.multidex = "com.android.support:multidex:$versions.android.multidex"
 android_deps.annotation = "androidx.annotation:annotation:$versions.android.annotation"
 android_deps.java_annotation = "javax.annotation:javax.annotation-api:$versions.android.javax_annotation"
 android_deps.desugar = "com.android.tools:desugar_jdk_libs:$versions.android.desugar"
@@ -78,7 +75,6 @@ testing_deps.ext_junit = "androidx.test.ext:junit:$versions.testing.ext_junit"
 testing_deps.runner = "androidx.test:runner:$versions.testing.core"
 testing_deps.rules = "androidx.test:rules:$versions.testing.core"
 testing_deps.espresso_core = "androidx.test.espresso:espresso-core:$versions.testing.espresso_core"
-testing_deps.support_rules = "com.android.support.test:rules:$versions.testing.support_rules"
 testing_deps.okhttp3 = "com.squareup.okhttp3:okhttp:$versions.testing.okhttp3"
 testing_deps.robolectric = "org.robolectric:robolectric:$versions.testing.robolectric"
 deps.testing = testing_deps

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,6 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Mon Oct 02 10:21:45 PDT 2023
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"

--- a/testApp/build.gradle
+++ b/testApp/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         applicationId "com.mobilecoin.lib.app"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -35,7 +35,6 @@ dependencies {
     implementation project(":android-sdk")
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation 'com.android.support:multidex:1.0.3'
     testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/testApp/build.gradle
+++ b/testApp/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation project(":android-sdk")
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.multidex:multidex:2.0.1'
     testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/testApp/build.gradle
+++ b/testApp/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         applicationId "com.mobilecoin.lib.app"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
### Motivation

This PR migrates android-sdk dependencies to AndroidX so Jetifier can be removed.

### In this PR
* Replace android.support dependencies with new androidx versions
* Remove Jetifier

