### PR TITLE
Add API for creating a Proof of Reserve SCI

### DIFF
--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '6.0.1'
+version '6.0.2'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/SignedContingentInputTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/SignedContingentInputTest.java
@@ -35,7 +35,7 @@ public class SignedContingentInputTest {
         final Amount[] requiredAmounts = sci.getRequiredOutputAmounts();
         final Amount pseudoOutputAmount = sci.getPseudoOutputAmount();
 
-        assertTrue(sci.isValid());
+        assertTrue(sci.isValid(true));
         assertTrue((requiredAmounts.length > 0) && (requiredAmounts.length <= 2));
 
         // Test Serialization
@@ -102,7 +102,7 @@ public class SignedContingentInputTest {
                 requiredAmount
         );
 
-        assertTrue(sci.isValid());
+        assertTrue(sci.isValid(true));
 
         Transaction transaction = consumerClient.prepareTransaction(sci, fee);
         consumerClient.submitTransaction(transaction);

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinTransactionClient.java
@@ -141,6 +141,18 @@ public interface MobileCoinTransactionClient {
   ) throws SerializationException, NetworkException, TransactionBuilderException, AttestationException, FogReportException, InvalidFogResponse, FogSyncException;
 
   /**
+   * Creates an unspendable {@link SignedContingentInput} that can be used to prove that the client is in possession of
+   * an unspent TxOut that is identified by a given TxOut public key.
+   *
+   * This works because the {@link SignedContingentInput} contains both the transaction amount and its keyimage, as well as
+   * an MLSAG signature that proves their validity.
+   */
+  @NonNull
+  SignedContingentInput createProofOfReserveSignedContingentInput(
+        @NonNull byte[] txOutPublicKeyBytes
+  ) throws SerializationException, SignedContingentInputBuilderException, NetworkException, FogReportException, InvalidFogResponse, TransactionBuilderException, AttestationException;
+
+  /**
    * Creates a {@link Transaction} to fulfill the provided {@link SignedContingentInput}. The resultant
    * {@link Transaction} can be submitted using {@link MobileCoinTransactionClient#submitTransaction(Transaction)}.
    * To process the {@link Transaction}, a small fee must be paid. The fee is subtracted from the reward
@@ -370,4 +382,3 @@ public interface MobileCoinTransactionClient {
   Amount getOrFetchMinimumTxFee(@NonNull TokenId tokenId) throws NetworkException;
 
 }
-

--- a/android-sdk/src/main/java/com/mobilecoin/lib/SignedContingentInput.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/SignedContingentInput.java
@@ -168,13 +168,19 @@ public class SignedContingentInput extends Native implements Parcelable {
      *
      * This functionality is only supported on networks with block version 3 or higher
      *
+     * Output checking is optional - we want that for SCIs we are planning on consuming, but need to skip it
+     * for proof of reserve SCIs.
+     *
      * @return true if this {@link SignedContingentInput} is valid, false otherwise
      * @see MobileCoinTransactionClient#prepareTransaction(SignedContingentInput, Amount)
      * @see MobileCoinTransactionClient#prepareTransaction(SignedContingentInput, Amount, Rng rng)
      * @since 4.0.0
      */
-    public boolean isValid() {
+    public boolean isValid(boolean checkOutputs) {
         if(!is_valid()) return false;
+
+        if (!checkOutputs) return true;
+
         final Amount[] requiredOutputAmounts = getRequiredOutputAmounts();
         final int numAmounts = requiredOutputAmounts.length;
         if((numAmounts > 0) && (numAmounts < 3)) {


### PR DESCRIPTION
### Motivation

We want Sentz to be able to generate Proof of Reserve SCIs. In order to do that, the `mobilecoin_flutter_plugin` needs to support that, and in order for it to support it, the underlying `android-sdk` (and `MobileCoin-Swift`) components need to support that.

### In this PR
* A helper method for creating a Proof of Reserve SCI
