### PR TITLE
ci: use mco-dev-small-x64 self hosted runner

### DIFF
--- a/.github/workflows/android-sdk-dispatch.yml
+++ b/.github/workflows/android-sdk-dispatch.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build_publish:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mco-dev-small-x64
 
     steps:
       - name: Checkout


### PR DESCRIPTION
The current GHA publish workflow is using the old self-hosted runner, we need to update to the new one.