### PR TITLE
try specifying a container

### DIFF
--- a/.github/workflows/android-sdk-dispatch.yml
+++ b/.github/workflows/android-sdk-dispatch.yml
@@ -1,4 +1,4 @@
-name: Publish Android SDK 
+name: Publish Android SDK
 
 on:
   workflow_dispatch:
@@ -6,6 +6,8 @@ on:
 jobs:
   build_publish:
     runs-on: mco-dev-small-x64
+    container:
+      image: ubuntu:22.04
 
     steps:
       - name: Checkout
@@ -17,4 +19,3 @@ jobs:
         working-directory: ./
         run: |
           make publish
-

--- a/.github/workflows/android-sdk-dispatch.yml
+++ b/.github/workflows/android-sdk-dispatch.yml
@@ -1,6 +1,9 @@
 name: Publish Android SDK
 
 on:
+  push:
+    branches:
+      - "eran/try-fix-github-release"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/android-sdk-dispatch.yml
+++ b/.github/workflows/android-sdk-dispatch.yml
@@ -8,9 +8,7 @@ on:
 
 jobs:
   build_publish:
-    runs-on: mco-dev-small-x64
-    container:
-      image: ubuntu:22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ build: setup
 		-w /home/gradle/ \
 		android-build:android-gradle \
 		gradle build
-	
+
 tests: setup
 	docker run \
 		-v $(pwd):/home/gradle/ \
@@ -46,14 +46,12 @@ publish: setup
 # May not need this but it allows publishing from local if needed
 	@if [ -z "${MAVEN_USER}" ]; then \
 		docker run \
-			-it \
 			-v $(pwd):/home/gradle/ \
 			-w /home/gradle/ android-build:android-gradle \
 			bash -c 'gradle clean && gradle assemble && gradle publish'; \
 	else \
 		echo "Running CI Publish"; \
 		docker run \
-			-it \
 			-v $(pwd):/home/gradle/ \
 			-e MAVEN_USER \
 			-e MAVEN_PASSWORD \
@@ -63,12 +61,11 @@ publish: setup
 
 bash: setup
 	docker run \
-		-it \
 		-v $(pwd):/home/gradle/ \
 		-v $(maven_repo):/root/.m2/ \
 		-w /home/gradle/ android-build:android-gradle \
 		bash
-	
+
 setup: dockerImage
 
 all: setup clean build deployLocal


### PR DESCRIPTION
Try and fix the release github action. I think this is a step in the right direction but I think it failing due to the MAVEN_ env vars not being set.
However, it appears CircleCI already handled the latest release: https://app.circleci.com/pipelines/github/mobilecoinofficial/android-sdk/794/workflows/215ef248-d6f3-407f-aab5-50f73305e7b0/jobs/958
so unless we want to transition to Github actions, we are good for now...