### PR TITLE
chore: update NDK to 28.0.13004108

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -50,6 +50,7 @@ protobuf {
 android {
     namespace 'com.mobilecoin.lib'
     testNamespace 'com.mobilecoin.lib.test'
+    ndkVersion "28.0.13004108"
     buildToolsVersion "31.0.0"
     compileSdkVersion build_versions.compile_sdk
     useLibrary 'android.test.runner'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 zipStoreBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip

--- a/makefile
+++ b/makefile
@@ -8,6 +8,7 @@ maven_repo=$(HOME)/.m2
 
 build: setup
 	docker run \
+        --platform linux/x86_64 \
 		-v $(pwd):/home/gradle/ \
 		-w /home/gradle/ \
 		android-build:android-gradle \
@@ -15,6 +16,7 @@ build: setup
 	
 tests: setup
 	docker run \
+        --platform linux/x86_64 \
 		-v $(pwd):/home/gradle/ \
 		-w /home/gradle/ \
 		android-build:android-gradle \
@@ -22,11 +24,13 @@ tests: setup
 
 dockerImage:
 	docker build \
+        --platform linux/x86_64 \
 		-t android-build:android-gradle \
 		docker
 
 clean:
 	docker run \
+        --platform linux/x86_64 \
 		-v $(pwd):/home/gradle/ \
 		-w /home/gradle/ \
 		android-build:android-gradle \
@@ -34,6 +38,7 @@ clean:
 
 deployLocal: setup
 	docker run \
+        --platform linux/x86_64 \
 		-v $(pwd):/home/gradle/ \
 		-v $(maven_repo):/root/.m2/ \
 		-w /home/gradle/ \


### PR DESCRIPTION
### Motivation

Update NDK version to r28 to support 16 kb page sizes

### In this PR

* Update NDK to 28.0.13004108
* Specify platform linux/x86_64 for docker builds to support building from M1 MacOS
* Update Gradle wrapper to 7.6