### PR TITLE
chore: update android-bindings to version to 6.02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.2] - 2025-4-18
+
+### Added
+- Update android-bindings to 6.0.2
+
+### Upgrading
+No code changes are *required* to upgrade from 6.1.1 to 6.1.2
+
 ## [6.1.1] - 2025-4-9
 
 ### Added

--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '6.1.1'
+version '6.1.2'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-sdk/versions.gradle
+++ b/android-sdk/versions.gradle
@@ -28,7 +28,7 @@ versions.network = network_versions
 
 // JNI
 def jni_versions = [:]
-jni_versions.mobilecoin = '6.0.1'
+jni_versions.mobilecoin = '6.0.2'
 versions.jni = jni_versions
 
 // Testing


### PR DESCRIPTION
### Motivation

In order to support 16KiB page sizes, `android-bindings` needed to be updated to use NDK r28. This SDK needs to use the updated `android-bindings` library to also support 16KiB page sizes.

### In this PR

Update `android-bindings` to version 6.0.2