### PR TITLE
Add payment id to payment requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.3] - 2025-12-2
+
+### Added
+- Added `paymentId` to the `PaymentRequest` API
+
+### Upgrading
+No code changes are *required* to upgrade from 6.1.1 to 6.1.2
+
 ## [6.1.2] - 2025-4-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `paymentId` to the `PaymentRequest` API
 
 ### Upgrading
-No code changes are *required* to upgrade from 6.1.1 to 6.1.2
+No code changes are *required* to upgrade from 6.1.2 to 6.1.3
 
 ## [6.1.2] - 2025-4-18
 

--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '6.1.2'
+version '6.1.3'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-sdk/src/androidTest/java/com/mobilecoin/lib/PrintableWrapperTest.java
+++ b/android-sdk/src/androidTest/java/com/mobilecoin/lib/PrintableWrapperTest.java
@@ -62,10 +62,12 @@ public class PrintableWrapperTest {
     public void test_payment_request_payload() throws SerializationException {
         PublicAddress publicAddress = TestKeysManager.getNextAccountKey().getPublicAddress();
         TokenId tokenId = TokenId.MOB;
+        UnsignedLong paymentId = UnsignedLong.valueOf(32);
         PaymentRequest paymentRequest = new PaymentRequest(publicAddress,
                 PAYLOAD_AMOUNT,
                 MEMO,
-                tokenId
+                tokenId,
+                paymentId
         );
         PrintableWrapper printableWrapper = PrintableWrapper.fromPaymentRequest(paymentRequest);
         Assert.assertFalse(
@@ -101,6 +103,25 @@ public class PrintableWrapperTest {
         Assert.assertEquals("Payment request must include token id",
                 printableWrapper.getPaymentRequest().getTokenId(),
                 tokenId);
+        Assert.assertEquals("Payment request must include payment id",
+                printableWrapper.getPaymentRequest().getPaymentId(),
+                paymentId);
+    }
+
+    @Test
+    public void test_payment_request_with_null_payment_id() throws SerializationException {
+        PublicAddress publicAddress = TestKeysManager.getNextAccountKey().getPublicAddress();
+        TokenId tokenId = TokenId.MOB;
+        PaymentRequest paymentRequest = new PaymentRequest(publicAddress,
+                PAYLOAD_AMOUNT,
+                MEMO,
+                tokenId,
+                null
+        );
+        String b58String = PrintableWrapper.fromPaymentRequest(paymentRequest).toB58String();
+        PrintableWrapper printableWrapper = PrintableWrapper.fromB58String(b58String);
+        Assert.assertNull("Payment request payment id must be null",
+                printableWrapper.getPaymentRequest().getPaymentId());
     }
 
     @Test

--- a/android-sdk/src/main/java/com/mobilecoin/lib/PaymentRequest.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/PaymentRequest.java
@@ -41,13 +41,15 @@ public final class PaymentRequest {
         TokenId tokenId = TokenId.from(
                 UnsignedLong.fromLongBits(protoBuf.getTokenId())
         );
-        UnsignedLong paymentId = protoBuf.getPaymentId();
+        long rawPaymentId = protoBuf.getPaymentId();
+        UnsignedLong paymentId = (rawPaymentId != 0) ?
+                UnsignedLong.fromLongBits(rawPaymentId) : null;
         return new PaymentRequest(
                 publicAddress,
                 UnsignedLong.fromLongBits(protoBuf.getValue()),
                 protoBuf.getMemo(),
                 tokenId,
-                paymentId == null ? null : UnsignedLong.fromLongBits(paymentId)
+                paymentId
         );
     }
 


### PR DESCRIPTION
### Motivation

`payment_id` is included in the protos for `PaymentRequest`, but still needed wiring for the android sdk.

### In this PR
* adds nullable `paymentId` to the `PaymentRequest` object
* tests `paymentId` in both null and non-null states
