### PR TITLE
perf(SENTZ-5454): bound per-poll key-image scan with a start_block watermark

### DIFF
--- a/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/AttestedLedgerClient.java
@@ -22,7 +22,7 @@ import com.mobilecoin.lib.util.NetworkingCall;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -160,6 +160,37 @@ class AttestedLedgerClient extends AttestedClient {
                             .setData(ByteString.copyFrom(keyImage.getData())).build()).build();
             keyImageQueries.add(query);
         }
+        return sendKeyImageQueries(keyImageQueries);
+    }
+
+    /**
+     * Query key images status
+     *
+     * @param txos a list of OwnedTxOuts whose key images to check
+     */
+    @NonNull
+    public synchronized Ledger.CheckKeyImagesResponse checkUtxoKeyImages(@NonNull Set<OwnedTxOut> txos)
+            throws InvalidFogResponse, AttestationException, NetworkException {
+        Logger.i(TAG, "Checking unspent OwnedTxOut key images");
+        ArrayList<Ledger.KeyImageQuery> keyImageQueries = new ArrayList<>();
+        for (OwnedTxOut txo : txos) {
+            // A txo confirmed unspent through block N only needs scanning forward from N.
+            // A txo never checked has no watermark, so it sends 0, a full history scan.
+            UnsignedLong knownUnspentThrough = txo.getKnownToBeUnspentBlockCount();
+            Ledger.KeyImageQuery query = Ledger.KeyImageQuery.newBuilder()
+                    .setKeyImage(MobileCoinAPI.KeyImage.newBuilder()
+                            .setData(ByteString.copyFrom(txo.getKeyImage().getData())).build())
+                    .setStartBlock(knownUnspentThrough == null ? 0L : knownUnspentThrough.longValue())
+                    .build();
+            keyImageQueries.add(query);
+        }
+        return sendKeyImageQueries(keyImageQueries);
+    }
+
+    @NonNull
+    private Ledger.CheckKeyImagesResponse sendKeyImageQueries(
+            @NonNull List<Ledger.KeyImageQuery> keyImageQueries
+    ) throws InvalidFogResponse, AttestationException, NetworkException {
         Ledger.CheckKeyImagesRequest imagesRequest =
                 Ledger.CheckKeyImagesRequest.newBuilder().addAllQueries(keyImageQueries)
                         .build();
@@ -190,22 +221,5 @@ class AttestedLedgerClient extends AttestedClient {
         } catch (Exception exception) {
             throw new IllegalStateException("BUG: unreachable code");
         }
-    }
-
-    /**
-     * Query key images status
-     *
-     * @param txos a list of OwnedTxOuts whose key images to check
-     */
-    @NonNull
-    public synchronized Ledger.CheckKeyImagesResponse checkUtxoKeyImages(@NonNull Set<OwnedTxOut> txos)
-            throws InvalidFogResponse, AttestationException, NetworkException {
-        Logger.i(TAG, "Checking unspent OwnedTxOut key images");
-        HashSet<KeyImage> keyImages = new HashSet<>();
-        for (OwnedTxOut txo : txos) {
-            KeyImage keyImage = txo.getKeyImage();
-            keyImages.add(keyImage);
-        }
-        return checkKeyImages(keyImages);
     }
 }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
@@ -42,11 +42,8 @@ public class OwnedTxOut implements Parcelable {
     private final Date receivedBlockTimestamp;
     private Date spentBlockTimestamp;
     private UnsignedLong spentBlockIndex;
-    // Highest block count fog-ledger has confirmed this key image unspent through.
-    // Scopes the next key-image scan to start_block; null means never checked.
-    // Not parcelled: Parcel has no per-object length prefix, so a field added here would
-    // misread trailing sibling bytes for every OwnedTxOut but the last in a cached blob.
-    // Resetting to null on process restart is always safe, it just forces one full scan.
+    // Highest block count fog-ledger confirmed this key image unspent through, null if never.
+    // Out of the parcel so a blob cached by another SDK version stays readable.
     @Nullable
     private UnsignedLong knownToBeUnspentBlockCount;
 

--- a/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/OwnedTxOut.java
@@ -42,6 +42,13 @@ public class OwnedTxOut implements Parcelable {
     private final Date receivedBlockTimestamp;
     private Date spentBlockTimestamp;
     private UnsignedLong spentBlockIndex;
+    // Highest block count fog-ledger has confirmed this key image unspent through.
+    // Scopes the next key-image scan to start_block; null means never checked.
+    // Not parcelled: Parcel has no per-object length prefix, so a field added here would
+    // misread trailing sibling bytes for every OwnedTxOut but the last in a cached blob.
+    // Resetting to null on process restart is always safe, it just forces one full scan.
+    @Nullable
+    private UnsignedLong knownToBeUnspentBlockCount;
 
     private final TxOutMemo cachedTxOutMemo;
 
@@ -138,6 +145,7 @@ public class OwnedTxOut implements Parcelable {
         this.receivedBlockTimestamp = original.receivedBlockTimestamp;
         this.spentBlockTimestamp = original.spentBlockTimestamp;
         this.spentBlockIndex = original.spentBlockIndex;
+        this.knownToBeUnspentBlockCount = original.knownToBeUnspentBlockCount;
         this.cachedTxOutMemo = original.cachedTxOutMemo;
         this.amount = original.amount;
         this.subaddressIndex = original.subaddressIndex;
@@ -245,6 +253,15 @@ public class OwnedTxOut implements Parcelable {
         this.spentBlockTimestamp = spentBlockTimestamp;
     }
 
+    @Nullable
+    synchronized UnsignedLong getKnownToBeUnspentBlockCount() {
+        return knownToBeUnspentBlockCount;
+    }
+
+    synchronized void setKnownToBeUnspentBlockCount(@NonNull UnsignedLong knownToBeUnspentBlockCount) {
+        this.knownToBeUnspentBlockCount = knownToBeUnspentBlockCount;
+    }
+
     @NonNull
     UnsignedLong getTxOutGlobalIndex() {
         return txOutGlobalIndex;
@@ -267,6 +284,7 @@ public class OwnedTxOut implements Parcelable {
                Objects.equals(this.receivedBlockTimestamp, that.receivedBlockTimestamp) &&
                Objects.equals(this.spentBlockTimestamp, that.spentBlockTimestamp) &&
                Objects.equals(this.spentBlockIndex, that.spentBlockIndex) &&
+               // knownToBeUnspentBlockCount is a scan-optimization hint, not part of identity.
                Objects.equals(this.amount, that.amount) &&
                Objects.equals(this.txOutPublicKey, that.txOutPublicKey) &&
                Objects.equals(this.txOutTargetKey, that.txOutTargetKey) &&

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
@@ -312,7 +312,11 @@ class TxOutStore implements Parcelable {
       return decommissionedIngestInvocationIds.contains(seed.getIngestInvocationId());
     }
 
-    void updateTxOutsSpentState(Ledger.CheckKeyImagesResponse keyImagesResponse) throws InvalidFogResponse {
+    void updateTxOutsSpentState(
+            @NonNull Set<OwnedTxOut> queriedTxOuts,
+            Ledger.CheckKeyImagesResponse keyImagesResponse
+    ) throws InvalidFogResponse {
+        Set<KeyImage> spentKeyImages = new HashSet<>();
         for (Ledger.KeyImageResult result : keyImagesResponse.getResultsList()) {
             if (result.getKeyImageResultCode() == Ledger.KeyImageResultCode.NotSpent_VALUE) {
                 continue;
@@ -335,11 +339,22 @@ class TxOutStore implements Parcelable {
                     UnsignedLong.fromLongBits(result.getSpentAt()),
                     spentBlockTimestamp
             );
+            spentKeyImages.add(utxo.getKeyImage());
             Logger.d(TAG, String.format(Locale.US,
                     "TxOut has been marked spent in block %s",
                     Objects.requireNonNull(utxo.getSpentBlockIndex()).toString())
             );
         }
+
+        // Every queried txo not found spent above is confirmed unspent through this block
+        // count, whether the server said NotSpent or omitted it, matching iOS's fallback.
+        UnsignedLong unspentThroughBlockCount = UnsignedLong.fromLongBits(keyImagesResponse.getNumBlocks());
+        for (OwnedTxOut txOut : queriedTxOuts) {
+            if (!spentKeyImages.contains(txOut.getKeyImage())) {
+                txOut.setKnownToBeUnspentBlockCount(unspentThroughBlockCount);
+            }
+        }
+
         synchronized (this) {
             ledgerTotalTxCount = UnsignedLong.fromLongBits(keyImagesResponse.getGlobalTxoCount());
             ledgerBlockIndex = UnsignedLong.fromLongBits(keyImagesResponse.getNumBlocks())
@@ -352,7 +367,7 @@ class TxOutStore implements Parcelable {
         Logger.i(TAG, "Checking unspent TXOs key images");
         Set<OwnedTxOut> txOuts = getUnspentTxOuts();
         Ledger.CheckKeyImagesResponse response = ledgerClient.checkUtxoKeyImages(txOuts);
-        updateTxOutsSpentState(response);
+        updateTxOutsSpentState(txOuts, response);
     }
 
     /**

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
@@ -316,9 +316,10 @@ class TxOutStore implements Parcelable {
             @NonNull Set<OwnedTxOut> queriedTxOuts,
             Ledger.CheckKeyImagesResponse keyImagesResponse
     ) throws InvalidFogResponse {
-        Set<KeyImage> spentKeyImages = new HashSet<>();
+        Set<KeyImage> notSpentKeyImages = new HashSet<>();
         for (Ledger.KeyImageResult result : keyImagesResponse.getResultsList()) {
             if (result.getKeyImageResultCode() == Ledger.KeyImageResultCode.NotSpent_VALUE) {
+                notSpentKeyImages.add(KeyImage.fromBytes(result.getKeyImage().getData().toByteArray()));
                 continue;
             }
 
@@ -339,18 +340,17 @@ class TxOutStore implements Parcelable {
                     UnsignedLong.fromLongBits(result.getSpentAt()),
                     spentBlockTimestamp
             );
-            spentKeyImages.add(utxo.getKeyImage());
             Logger.d(TAG, String.format(Locale.US,
                     "TxOut has been marked spent in block %s",
                     Objects.requireNonNull(utxo.getSpentBlockIndex()).toString())
             );
         }
 
-        // Every queried txo not found spent above is confirmed unspent through this block
-        // count, whether the server said NotSpent or omitted it, matching iOS's fallback.
+        // Only a returned NotSpent result licenses skipping blocks. The unspent-through
+        // guarantee is attached to the result, so an omitted one keeps the full scan.
         UnsignedLong unspentThroughBlockCount = UnsignedLong.fromLongBits(keyImagesResponse.getNumBlocks());
         for (OwnedTxOut txOut : queriedTxOuts) {
-            if (!spentKeyImages.contains(txOut.getKeyImage())) {
+            if (notSpentKeyImages.contains(txOut.getKeyImage())) {
                 txOut.setKnownToBeUnspentBlockCount(unspentThroughBlockCount);
             }
         }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/TxOutStore.java
@@ -346,8 +346,8 @@ class TxOutStore implements Parcelable {
             );
         }
 
-        // Only a returned NotSpent result licenses skipping blocks. The unspent-through
-        // guarantee is attached to the result, so an omitted one keeps the full scan.
+        // Only a returned NotSpent result licenses skipping blocks, since the proto attaches
+        // its unspent-through guarantee to a result rather than to a missing one.
         UnsignedLong unspentThroughBlockCount = UnsignedLong.fromLongBits(keyImagesResponse.getNumBlocks());
         for (OwnedTxOut txOut : queriedTxOuts) {
             if (notSpentKeyImages.contains(txOut.getKeyImage())) {

--- a/android-sdk/src/test/java/com/mobilecoin/lib/AttestedLedgerClientWatermarkTest.java
+++ b/android-sdk/src/test/java/com/mobilecoin/lib/AttestedLedgerClientWatermarkTest.java
@@ -1,0 +1,82 @@
+// Copyright (c) 2020-2026 MobileCoin. All rights reserved.
+
+package com.mobilecoin.lib;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.ByteString;
+import com.mobilecoin.api.MobileCoinAPI;
+import com.mobilecoin.lib.network.services.FogKeyImageService;
+import com.mobilecoin.lib.network.services.ServiceAPIManager;
+import com.mobilecoin.lib.network.services.transport.Transport;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import attest.Attest;
+import fog_ledger.Ledger;
+
+/**
+ * Covers the per-txo start_block watermark reaching the wire in each key-image query.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class AttestedLedgerClientWatermarkTest {
+
+    @Test
+    public void checkUtxoKeyImages_scopesEachQueryToThatTxOutsWatermark() throws Exception {
+        byte[] watermarkedKeyImage = {1};
+        OwnedTxOut watermarked = mock(OwnedTxOut.class);
+        when(watermarked.getKeyImage()).thenReturn(KeyImage.fromBytes(watermarkedKeyImage));
+        when(watermarked.getKnownToBeUnspentBlockCount())
+                .thenReturn(UnsignedLong.fromLongBits(50));
+
+        byte[] neverCheckedKeyImage = {2};
+        OwnedTxOut neverChecked = mock(OwnedTxOut.class);
+        when(neverChecked.getKeyImage()).thenReturn(KeyImage.fromBytes(neverCheckedKeyImage));
+        when(neverChecked.getKnownToBeUnspentBlockCount()).thenReturn(null);
+
+        FogKeyImageService keyImageService = mock(FogKeyImageService.class);
+        when(keyImageService.checkKeyImages(any())).thenReturn(Attest.Message.getDefaultInstance());
+        ServiceAPIManager apiManager = mock(ServiceAPIManager.class);
+        when(apiManager.getFogKeyImageService(any())).thenReturn(keyImageService);
+
+        AttestedLedgerClient client = mock(AttestedLedgerClient.class, CALLS_REAL_METHODS);
+        ArgumentCaptor<Ledger.CheckKeyImagesRequest> sentRequest =
+                ArgumentCaptor.forClass(Ledger.CheckKeyImagesRequest.class);
+        doReturn(apiManager).when(client).getAPIManager();
+        doReturn(mock(Transport.class)).when(client).getNetworkTransport();
+        doReturn(Attest.Message.getDefaultInstance())
+                .when(client).encryptMessage(sentRequest.capture());
+        doReturn(Attest.Message.newBuilder()
+                .setData(Ledger.CheckKeyImagesResponse.getDefaultInstance().toByteString())
+                .build()).when(client).decryptMessage(any());
+
+        client.checkUtxoKeyImages(new HashSet<>(Arrays.asList(watermarked, neverChecked)));
+
+        Ledger.CheckKeyImagesRequest request = sentRequest.getValue();
+        assertEquals(2, request.getQueriesCount());
+        assertEquals(50L, startBlockFor(request, watermarkedKeyImage));
+        assertEquals(0L, startBlockFor(request, neverCheckedKeyImage));
+    }
+
+    private static long startBlockFor(Ledger.CheckKeyImagesRequest request, byte[] keyImage) {
+        MobileCoinAPI.KeyImage queried = MobileCoinAPI.KeyImage.newBuilder()
+                .setData(ByteString.copyFrom(keyImage)).build();
+        for (Ledger.KeyImageQuery query : request.getQueriesList()) {
+            if (query.getKeyImage().equals(queried)) {
+                return query.getStartBlock();
+            }
+        }
+        throw new AssertionError("no query carried the given key image");
+    }
+}

--- a/android-sdk/src/test/java/com/mobilecoin/lib/AttestedLedgerClientWatermarkTest.java
+++ b/android-sdk/src/test/java/com/mobilecoin/lib/AttestedLedgerClientWatermarkTest.java
@@ -34,16 +34,15 @@ public class AttestedLedgerClientWatermarkTest {
 
     @Test
     public void checkUtxoKeyImages_scopesEachQueryToThatTxOutsWatermark() throws Exception {
+        // Real watermark accessors, so an accessor that stopped storing the value fails here.
         byte[] watermarkedKeyImage = {1};
-        OwnedTxOut watermarked = mock(OwnedTxOut.class);
-        when(watermarked.getKeyImage()).thenReturn(KeyImage.fromBytes(watermarkedKeyImage));
-        when(watermarked.getKnownToBeUnspentBlockCount())
-                .thenReturn(UnsignedLong.fromLongBits(50));
+        OwnedTxOut watermarked = mock(OwnedTxOut.class, CALLS_REAL_METHODS);
+        doReturn(KeyImage.fromBytes(watermarkedKeyImage)).when(watermarked).getKeyImage();
+        watermarked.setKnownToBeUnspentBlockCount(UnsignedLong.fromLongBits(50));
 
         byte[] neverCheckedKeyImage = {2};
-        OwnedTxOut neverChecked = mock(OwnedTxOut.class);
-        when(neverChecked.getKeyImage()).thenReturn(KeyImage.fromBytes(neverCheckedKeyImage));
-        when(neverChecked.getKnownToBeUnspentBlockCount()).thenReturn(null);
+        OwnedTxOut neverChecked = mock(OwnedTxOut.class, CALLS_REAL_METHODS);
+        doReturn(KeyImage.fromBytes(neverCheckedKeyImage)).when(neverChecked).getKeyImage();
 
         FogKeyImageService keyImageService = mock(FogKeyImageService.class);
         when(keyImageService.checkKeyImages(any())).thenReturn(Attest.Message.getDefaultInstance());

--- a/android-sdk/src/test/java/com/mobilecoin/lib/TxOutStoreWatermarkTest.java
+++ b/android-sdk/src/test/java/com/mobilecoin/lib/TxOutStoreWatermarkTest.java
@@ -1,0 +1,96 @@
+// Copyright (c) 2020-2026 MobileCoin. All rights reserved.
+
+package com.mobilecoin.lib;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.ByteString;
+import com.mobilecoin.api.MobileCoinAPI;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import fog_ledger.Ledger;
+
+/**
+ * Covers the per-txo start_block watermark, the fix for SENTZ-5454.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class TxOutStoreWatermarkTest {
+
+    @Test
+    public void updateTxOutsSpentState_watermarksOnlyTxOutsConfirmedUnspent() throws Exception {
+        TxOutStore store = new TxOutStore(null);
+
+        byte[] spentKeyImageBytes = {1};
+        OwnedTxOut spentTxOut = mock(OwnedTxOut.class);
+        when(spentTxOut.getKeyImageHashCode()).thenReturn(Arrays.hashCode(spentKeyImageBytes));
+        when(spentTxOut.getKeyImage()).thenReturn(KeyImage.fromBytes(spentKeyImageBytes));
+        when(spentTxOut.getSpentBlockIndex()).thenReturn(UnsignedLong.ONE);
+
+        byte[] unspentKeyImageBytes = {2};
+        OwnedTxOut unspentTxOut = mock(OwnedTxOut.class);
+        when(unspentTxOut.getKeyImage()).thenReturn(KeyImage.fromBytes(unspentKeyImageBytes));
+
+        // getUtxoByKeyImage resolves a Spent result against the store's own synced set, not the
+        // queried set, so the spent txo needs to be reachable that way too.
+        Field recoveredTxOutsField = TxOutStore.class.getDeclaredField("recoveredTxOuts");
+        recoveredTxOutsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        ConcurrentLinkedQueue<OwnedTxOut> recoveredTxOuts =
+                (ConcurrentLinkedQueue<OwnedTxOut>) recoveredTxOutsField.get(store);
+        recoveredTxOuts.add(spentTxOut);
+
+        Ledger.CheckKeyImagesResponse response = Ledger.CheckKeyImagesResponse.newBuilder()
+                .setNumBlocks(50)
+                .setGlobalTxoCount(100)
+                .addResults(Ledger.KeyImageResult.newBuilder()
+                        .setKeyImage(MobileCoinAPI.KeyImage.newBuilder()
+                                .setData(ByteString.copyFrom(spentKeyImageBytes)).build())
+                        .setKeyImageResultCode(Ledger.KeyImageResultCode.Spent_VALUE)
+                        .setSpentAt(10)
+                        .setTimestamp(UnsignedLong.MAX_VALUE.longValue())
+                        .build())
+                .build();
+
+        Set<OwnedTxOut> queried = new HashSet<>(Arrays.asList(spentTxOut, unspentTxOut));
+        store.updateTxOutsSpentState(queried, response);
+
+        verify(spentTxOut, never()).setKnownToBeUnspentBlockCount(any());
+        verify(unspentTxOut).setKnownToBeUnspentBlockCount(UnsignedLong.fromLongBits(50));
+    }
+
+    @Test
+    public void updateTxOutsSpentState_watermarksAnExplicitNotSpentResult() throws Exception {
+        TxOutStore store = new TxOutStore(null);
+
+        byte[] notSpentKeyImageBytes = {3};
+        OwnedTxOut notSpentTxOut = mock(OwnedTxOut.class);
+        when(notSpentTxOut.getKeyImage()).thenReturn(KeyImage.fromBytes(notSpentKeyImageBytes));
+
+        Ledger.CheckKeyImagesResponse response = Ledger.CheckKeyImagesResponse.newBuilder()
+                .setNumBlocks(75)
+                .setGlobalTxoCount(200)
+                .addResults(Ledger.KeyImageResult.newBuilder()
+                        .setKeyImage(MobileCoinAPI.KeyImage.newBuilder()
+                                .setData(ByteString.copyFrom(notSpentKeyImageBytes)).build())
+                        .setKeyImageResultCode(Ledger.KeyImageResultCode.NotSpent_VALUE)
+                        .build())
+                .build();
+
+        store.updateTxOutsSpentState(new HashSet<>(Arrays.asList(notSpentTxOut)), response);
+
+        verify(notSpentTxOut).setKnownToBeUnspentBlockCount(UnsignedLong.fromLongBits(75));
+    }
+}

--- a/android-sdk/src/test/java/com/mobilecoin/lib/TxOutStoreWatermarkTest.java
+++ b/android-sdk/src/test/java/com/mobilecoin/lib/TxOutStoreWatermarkTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import fog_ledger.Ledger;
 
 /**
- * Covers the per-txo start_block watermark, the fix for SENTZ-5454.
+ * Covers the per-txo start_block watermark set from key-image results.
  */
 @RunWith(RobolectricTestRunner.class)
 public class TxOutStoreWatermarkTest {

--- a/android-sdk/src/test/java/com/mobilecoin/lib/TxOutStoreWatermarkTest.java
+++ b/android-sdk/src/test/java/com/mobilecoin/lib/TxOutStoreWatermarkTest.java
@@ -30,7 +30,7 @@ import fog_ledger.Ledger;
 public class TxOutStoreWatermarkTest {
 
     @Test
-    public void updateTxOutsSpentState_watermarksOnlyTxOutsConfirmedUnspent() throws Exception {
+    public void updateTxOutsSpentState_watermarksOnlyAnExplicitNotSpentResult() throws Exception {
         TxOutStore store = new TxOutStore(null);
 
         byte[] spentKeyImageBytes = {1};
@@ -39,9 +39,13 @@ public class TxOutStoreWatermarkTest {
         when(spentTxOut.getKeyImage()).thenReturn(KeyImage.fromBytes(spentKeyImageBytes));
         when(spentTxOut.getSpentBlockIndex()).thenReturn(UnsignedLong.ONE);
 
-        byte[] unspentKeyImageBytes = {2};
-        OwnedTxOut unspentTxOut = mock(OwnedTxOut.class);
-        when(unspentTxOut.getKeyImage()).thenReturn(KeyImage.fromBytes(unspentKeyImageBytes));
+        byte[] notSpentKeyImageBytes = {2};
+        OwnedTxOut notSpentTxOut = mock(OwnedTxOut.class);
+        when(notSpentTxOut.getKeyImage()).thenReturn(KeyImage.fromBytes(notSpentKeyImageBytes));
+
+        byte[] omittedKeyImageBytes = {3};
+        OwnedTxOut omittedTxOut = mock(OwnedTxOut.class);
+        when(omittedTxOut.getKeyImage()).thenReturn(KeyImage.fromBytes(omittedKeyImageBytes));
 
         // getUtxoByKeyImage resolves a Spent result against the store's own synced set, not the
         // queried set, so the spent txo needs to be reachable that way too.
@@ -62,26 +66,6 @@ public class TxOutStoreWatermarkTest {
                         .setSpentAt(10)
                         .setTimestamp(UnsignedLong.MAX_VALUE.longValue())
                         .build())
-                .build();
-
-        Set<OwnedTxOut> queried = new HashSet<>(Arrays.asList(spentTxOut, unspentTxOut));
-        store.updateTxOutsSpentState(queried, response);
-
-        verify(spentTxOut, never()).setKnownToBeUnspentBlockCount(any());
-        verify(unspentTxOut).setKnownToBeUnspentBlockCount(UnsignedLong.fromLongBits(50));
-    }
-
-    @Test
-    public void updateTxOutsSpentState_watermarksAnExplicitNotSpentResult() throws Exception {
-        TxOutStore store = new TxOutStore(null);
-
-        byte[] notSpentKeyImageBytes = {3};
-        OwnedTxOut notSpentTxOut = mock(OwnedTxOut.class);
-        when(notSpentTxOut.getKeyImage()).thenReturn(KeyImage.fromBytes(notSpentKeyImageBytes));
-
-        Ledger.CheckKeyImagesResponse response = Ledger.CheckKeyImagesResponse.newBuilder()
-                .setNumBlocks(75)
-                .setGlobalTxoCount(200)
                 .addResults(Ledger.KeyImageResult.newBuilder()
                         .setKeyImage(MobileCoinAPI.KeyImage.newBuilder()
                                 .setData(ByteString.copyFrom(notSpentKeyImageBytes)).build())
@@ -89,8 +73,12 @@ public class TxOutStoreWatermarkTest {
                         .build())
                 .build();
 
-        store.updateTxOutsSpentState(new HashSet<>(Arrays.asList(notSpentTxOut)), response);
+        Set<OwnedTxOut> queried =
+                new HashSet<>(Arrays.asList(spentTxOut, notSpentTxOut, omittedTxOut));
+        store.updateTxOutsSpentState(queried, response);
 
-        verify(notSpentTxOut).setKnownToBeUnspentBlockCount(UnsignedLong.fromLongBits(75));
+        verify(notSpentTxOut).setKnownToBeUnspentBlockCount(UnsignedLong.fromLongBits(50));
+        verify(spentTxOut, never()).setKnownToBeUnspentBlockCount(any());
+        verify(omittedTxOut, never()).setKnownToBeUnspentBlockCount(any());
     }
 }


### PR DESCRIPTION
The app polls balance every 10 seconds. Each poll checks every owned txo's key image against fog-ledger unconditionally. `fog/api/proto/ledger.proto`'s `KeyImageQuery.start_block` exists to avoid this. A client that already knows a key image was unspent as of block N can scan forward from there. Android never populated it. iOS's `FogKeyImageChecker` already does this with a per-key-image watermark.

This adds the same watermark on Android. `OwnedTxOut` gets a nullable `knownToBeUnspentBlockCount`, set only from an explicit `NotSpent` result carrying that exact key image, in `TxOutStore.updateTxOutsSpentState`. That is stricter than iOS, which also treats an omitted key image as unspent, because the proto attaches its unspent-through guarantee to a returned result. `AttestedLedgerClient.checkUtxoKeyImages` threads the watermark into `start_block`, 0 for a txo without one.

The field is not persisted through `OwnedTxOut`'s Parcelable implementation. A blob cached by one SDK version can be read back by another, and the two would disagree about the field set. Rebuilding the watermark costs one full scan after a process restart, always a safe fallback.

Worth knowing before this merges: the fog-ledger enclave at the pinned foundation revision `05cb699` discards `start_block`. `check_key_images` in `fog/ledger/enclave/impl/src/lib.rs` maps every query through `store.find_record(&key.key_image)`, a single ORAM point read with no block loop, so the client-side win only lands once fog honors the field.

`make tests` needs CI-injected mnemonics and isn't runnable locally, this PR relies on CI for it. `make build` passed locally, including the new unit tests.
