### PR TITLE
chore: bump version to 6.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.4] - 2026-8-25
+
+### Changed
+- Bound the per-poll key-image scan with a per-txo `start_block` watermark
+
+### Upgrading
+No code changes are *required* to upgrade from 6.1.3 to 6.1.4
+
 ## [6.1.3] - 2025-12-2
 
 ### Added

--- a/android-sdk/publish.gradle
+++ b/android-sdk/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '6.1.3'
+version '6.1.4'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()


### PR DESCRIPTION
* Bump `version` in `android-sdk/publish.gradle` to 6.1.4.
* Add the matching `[6.1.4]` CHANGELOG entry for the key-image scan watermark shipped in #153.