### PR TITLE
ci(SENTZ-5470): Publish the android-sdk from a builder container

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels:
+  - mco-dev-large-x64
+  - mco-dev-small-x64

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,4 @@
 self-hosted-runner:
-  # Labels of self-hosted runner in array of string
   labels:
   - mco-dev-large-x64
   - mco-dev-small-x64

--- a/.github/workflows/android-sdk-dispatch.yml
+++ b/.github/workflows/android-sdk-dispatch.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: mco-dev-large-x64
     timeout-minutes: 60
     container:
-      image: mobilecoin/android-sdk-builder:latest
+      image: mobilecoin/android-sdk:latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/android-sdk-dispatch.yml
+++ b/.github/workflows/android-sdk-dispatch.yml
@@ -32,43 +32,6 @@ jobs:
             echo "tag ${GITHUB_REF_NAME} would publish version ${version}"
             exit 1
           fi
-      # Proves the credentials are accepted for read. Cloudsmith can scope read
-      # and write separately, so this rules out a dead credential in seconds
-      # without proving the publish itself will be authorised.
-      - name: Check Cloudsmith accepts the credentials
-        shell: bash
-        env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-        run: |
-          # curl reads the credentials from a config on stdin, which keeps them
-          # off the process command line and, unlike a netrc file, does not
-          # truncate a value containing a space.
-          # A curl config is parsed line by line, so a newline in a value would
-          # end the quoted string and let the rest be read as further options.
-          case "${MAVEN_USER}${MAVEN_PASSWORD}" in
-            *[$'\n\r']*)
-              echo "A Cloudsmith credential contains a newline, refusing to use it"
-              exit 1
-              ;;
-          esac
-          escape() { printf '%s' "$1" | sed 's/[\\"]/\\&/g'; }
-          probe=https://maven.cloudsmith.io/mobilecoin/mobilecoin/com/mobilecoin/android-sdk/maven-metadata.xml
-          code=$(printf 'user = "%s:%s"\n' "$(escape "${MAVEN_USER}")" "$(escape "${MAVEN_PASSWORD}")" \
-            | curl -sS -K - --retry 3 --retry-connrefused --max-time 30 \
-              -o /dev/null -w '%{http_code}' "${probe}") || code=000
-          case "${code}" in
-            # The probe path is version independent and known to exist, so a 404
-            # here means Cloudsmith is hiding it from us, not that it is missing.
-            401|403|404)
-              echo "Cloudsmith rejected the publish credentials, HTTP ${code}"
-              exit 1
-              ;;
-            2*) ;;
-            # Anything else is Cloudsmith being unwell, not a bad credential.
-            # Let the real publish decide rather than failing the release here.
-            *) echo "Could not reach Cloudsmith to check credentials, HTTP ${code}" ;;
-          esac
       - name: Build and Publish the SDK
         shell: bash
         env:

--- a/.github/workflows/android-sdk-dispatch.yml
+++ b/.github/workflows/android-sdk-dispatch.yml
@@ -6,6 +6,13 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-android-sdk
+  cancel-in-progress: false
+
 jobs:
   build_publish:
     runs-on: mco-dev-large-x64
@@ -17,29 +24,45 @@ jobs:
         uses: mobilecoinofficial/gh-actions/checkout@v0
       - name: Check the tag matches the version being published
         if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
         run: |
           version=$(sed -n "s/^version '\(.*\)'/\1/p" android-sdk/publish.gradle)
           if [ "${GITHUB_REF_NAME#v}" != "${version}" ]; then
             echo "tag ${GITHUB_REF_NAME} would publish version ${version}"
             exit 1
           fi
-      # Fail on bad credentials in seconds rather than after the build.
-      - name: Check the Cloudsmith credentials work
+      # Proves the credentials are accepted for read. Cloudsmith can scope read
+      # and write separately, so this rules out a dead credential in seconds
+      # without proving the publish itself will be authorised.
+      - name: Check Cloudsmith accepts the credentials
+        shell: bash
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         run: |
-          probe=https://maven.cloudsmith.io/mobilecoin/mobilecoin/com/mobilecoin/android-sdk/6.1.3/android-sdk-6.1.3.pom
-          code=$(curl -sS -u "${MAVEN_USER}:${MAVEN_PASSWORD}" -o /dev/null -w '%{http_code}' "${probe}")
-          if [ "${code}" != "200" ]; then
-            echo "Cloudsmith rejected the publish credentials, HTTP ${code}"
-            exit 1
-          fi
+          # A netrc file keeps the password off the process command line.
+          netrc=$(mktemp)
+          trap 'rm -f "${netrc}"' EXIT
+          umask 077
+          printf 'machine maven.cloudsmith.io login %s password %s\n' \
+            "${MAVEN_USER}" "${MAVEN_PASSWORD}" > "${netrc}"
+          probe=https://maven.cloudsmith.io/mobilecoin/mobilecoin/com/mobilecoin/android-sdk/maven-metadata.xml
+          code=$(curl -sS --netrc-file "${netrc}" --retry 3 --retry-connrefused \
+            --max-time 30 -o /dev/null -w '%{http_code}' "${probe}") || code=000
+          case "${code}" in
+            401|403)
+              echo "Cloudsmith rejected the publish credentials, HTTP ${code}"
+              exit 1
+              ;;
+            200) ;;
+            # Anything else is Cloudsmith being unwell, not a bad credential.
+            # Let the real publish decide rather than failing the release here.
+            *) echo "Could not reach Cloudsmith to check credentials, HTTP ${code}" ;;
+          esac
       - name: Build and Publish the SDK
+        shell: bash
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         run: |
-          gradle clean
-          gradle assemble
-          gradle publish
+          make publishDirect

--- a/.github/workflows/android-sdk-dispatch.yml
+++ b/.github/workflows/android-sdk-dispatch.yml
@@ -44,6 +44,14 @@ jobs:
           # curl reads the credentials from a config on stdin, which keeps them
           # off the process command line and, unlike a netrc file, does not
           # truncate a value containing a space.
+          # A curl config is parsed line by line, so a newline in a value would
+          # end the quoted string and let the rest be read as further options.
+          case "${MAVEN_USER}${MAVEN_PASSWORD}" in
+            *[$'\n\r']*)
+              echo "A Cloudsmith credential contains a newline, refusing to use it"
+              exit 1
+              ;;
+          esac
           escape() { printf '%s' "$1" | sed 's/[\\"]/\\&/g'; }
           probe=https://maven.cloudsmith.io/mobilecoin/mobilecoin/com/mobilecoin/android-sdk/maven-metadata.xml
           code=$(printf 'user = "%s:%s"\n' "$(escape "${MAVEN_USER}")" "$(escape "${MAVEN_PASSWORD}")" \

--- a/.github/workflows/android-sdk-dispatch.yml
+++ b/.github/workflows/android-sdk-dispatch.yml
@@ -8,11 +8,13 @@ on:
 
 jobs:
   build_publish:
-    runs-on: mco-dev-small-x64
+    runs-on: mco-dev-large-x64
+    container:
+      image: mobilecoin/android-sdk-builder:latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: mobilecoinofficial/gh-actions/checkout@v0
       - name: Check the tag matches the version being published
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -21,10 +23,23 @@ jobs:
             echo "tag ${GITHUB_REF_NAME} would publish version ${version}"
             exit 1
           fi
+      # Fail on bad credentials in seconds rather than after the build.
+      - name: Check the Cloudsmith credentials work
+        env:
+          MAVEN_USER: ${{ secrets.MAVEN_USER }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+        run: |
+          probe=https://maven.cloudsmith.io/mobilecoin/mobilecoin/com/mobilecoin/android-sdk/6.1.3/android-sdk-6.1.3.pom
+          code=$(curl -sS -u "${MAVEN_USER}:${MAVEN_PASSWORD}" -o /dev/null -w '%{http_code}' "${probe}")
+          if [ "${code}" != "200" ]; then
+            echo "Cloudsmith rejected the publish credentials, HTTP ${code}"
+            exit 1
+          fi
       - name: Build and Publish the SDK
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-        working-directory: ./
         run: |
-          make publish
+          gradle clean
+          gradle assemble
+          gradle publish

--- a/.github/workflows/android-sdk-dispatch.yml
+++ b/.github/workflows/android-sdk-dispatch.yml
@@ -10,12 +10,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: publish-android-sdk
+  group: publish-android-sdk-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   build_publish:
     runs-on: mco-dev-large-x64
+    timeout-minutes: 60
     container:
       image: mobilecoin/android-sdk-builder:latest
 
@@ -40,21 +41,22 @@ jobs:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         run: |
-          # A netrc file keeps the password off the process command line.
-          netrc=$(mktemp)
-          trap 'rm -f "${netrc}"' EXIT
-          umask 077
-          printf 'machine maven.cloudsmith.io login %s password %s\n' \
-            "${MAVEN_USER}" "${MAVEN_PASSWORD}" > "${netrc}"
+          # curl reads the credentials from a config on stdin, which keeps them
+          # off the process command line and, unlike a netrc file, does not
+          # truncate a value containing a space.
+          escape() { printf '%s' "$1" | sed 's/[\\"]/\\&/g'; }
           probe=https://maven.cloudsmith.io/mobilecoin/mobilecoin/com/mobilecoin/android-sdk/maven-metadata.xml
-          code=$(curl -sS --netrc-file "${netrc}" --retry 3 --retry-connrefused \
-            --max-time 30 -o /dev/null -w '%{http_code}' "${probe}") || code=000
+          code=$(printf 'user = "%s:%s"\n' "$(escape "${MAVEN_USER}")" "$(escape "${MAVEN_PASSWORD}")" \
+            | curl -sS -K - --retry 3 --retry-connrefused --max-time 30 \
+              -o /dev/null -w '%{http_code}' "${probe}") || code=000
           case "${code}" in
-            401|403)
+            # The probe path is version independent and known to exist, so a 404
+            # here means Cloudsmith is hiding it from us, not that it is missing.
+            401|403|404)
               echo "Cloudsmith rejected the publish credentials, HTTP ${code}"
               exit 1
               ;;
-            200) ;;
+            2*) ;;
             # Anything else is Cloudsmith being unwell, not a bad credential.
             # Let the real publish decide rather than failing the release here.
             *) echo "Could not reach Cloudsmith to check credentials, HTTP ${code}" ;;

--- a/.github/workflows/build-docker-dispatch.yaml
+++ b/.github/workflows/build-docker-dispatch.yaml
@@ -31,6 +31,6 @@ jobs:
         # Only master moves :latest, which is the tag the publish job pulls.
         # A dispatch from a branch still gets its own branch and sha tags.
         flavor: |
-          latest=${{ github.ref_name == 'master' }}
+          latest=${{ github.ref_name == github.event.repository.default_branch }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
         username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build-docker-dispatch.yaml
+++ b/.github/workflows/build-docker-dispatch.yaml
@@ -1,0 +1,24 @@
+name: Publish Build Docker Image
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  build_and_publish_docker:
+    runs-on: mco-dev-small-x64
+    steps:
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
+    - name: Docker
+      uses: mobilecoinofficial/gh-actions/docker@v0
+      with:
+        dockerfile: docker/Dockerfile
+        context: docker/
+        images: mobilecoin/android-sdk-builder
+        tags: |
+          ${{ github.ref_name }}
+          type=sha
+        flavor: |
+          latest=true
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build-docker-dispatch.yaml
+++ b/.github/workflows/build-docker-dispatch.yaml
@@ -1,7 +1,17 @@
 name: Publish Build Docker Image
 
 on:
+  # Rebuild whenever the image definition changes, so the published image
+  # cannot drift from docker/Dockerfile.
+  push:
+    branches:
+      - master
+    paths:
+      - 'docker/**'
   workflow_dispatch: {}
+
+permissions:
+  contents: read
 
 jobs:
   build_and_publish_docker:
@@ -18,7 +28,9 @@ jobs:
         tags: |
           ${{ github.ref_name }}
           type=sha
+        # Only master moves :latest, which is the tag the publish job pulls.
+        # A dispatch from a branch still gets its own branch and sha tags.
         flavor: |
-          latest=true
+          latest=${{ github.ref_name == 'master' }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
         username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build-docker-dispatch.yaml
+++ b/.github/workflows/build-docker-dispatch.yaml
@@ -1,8 +1,6 @@
 name: Publish Build Docker Image
 
 on:
-  # Rebuild whenever the image definition changes, so the published image
-  # cannot drift from docker/Dockerfile.
   push:
     branches:
       - master
@@ -16,6 +14,7 @@ permissions:
 jobs:
   build_and_publish_docker:
     runs-on: mco-dev-small-x64
+    timeout-minutes: 60
     steps:
     - name: Checkout
       uses: mobilecoinofficial/gh-actions/checkout@v0
@@ -28,8 +27,7 @@ jobs:
         tags: |
           ${{ github.ref_name }}
           type=sha
-        # Only master moves :latest, which is the tag the publish job pulls.
-        # A dispatch from a branch still gets its own branch and sha tags.
+        # android-sdk-dispatch.yml pulls :latest, so only master may move it.
         flavor: |
           latest=${{ github.ref_name == github.event.repository.default_branch }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-docker-dispatch.yaml
+++ b/.github/workflows/build-docker-dispatch.yaml
@@ -23,7 +23,7 @@ jobs:
       with:
         dockerfile: docker/Dockerfile
         context: docker/
-        images: mobilecoin/android-sdk-builder
+        images: mobilecoin/android-sdk
         tags: |
           ${{ github.ref_name }}
           type=sha

--- a/makefile
+++ b/makefile
@@ -45,6 +45,13 @@ deployLocal: setup
 		android-build:android-gradle \
 		gradle publishToMavenLocal
 
+# What publishing actually is. CI runs this directly inside the builder
+# container, so the steps stay defined in one place.
+publishDirect:
+	gradle clean
+	gradle assemble
+	gradle publish
+
 publish: setup
 # Without MAVEN_USER the credentials come from local.properties, so publishing
 # from a workstation works the same way.
@@ -53,7 +60,7 @@ publish: setup
 			-i \
 			-v $(pwd):/home/gradle/ \
 			-w /home/gradle/ android-build:android-gradle \
-			bash -c 'gradle clean && gradle assemble && gradle publish'; \
+			make publishDirect; \
 	else \
 		echo "Running CI Publish"; \
 		docker run \
@@ -62,7 +69,7 @@ publish: setup
 			-e MAVEN_USER \
 			-e MAVEN_PASSWORD \
 			-w /home/gradle/ android-build:android-gradle \
-			bash -c 'gradle clean && gradle assemble && gradle publish'; \
+			make publishDirect; \
 	fi
 
 bash: setup

--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ pwd=$(shell pwd)
 #default local maven deployment path
 maven_repo=$(HOME)/.m2
 
-.PHONY : build tests dockerImage clean deployLocal bash setup all
+.PHONY : build tests dockerImage clean deployLocal bash setup all publish publishDirect
 
 build: setup
 	docker run \

--- a/makefile
+++ b/makefile
@@ -51,24 +51,14 @@ publishDirect:
 	gradle publish
 
 publish: setup
-# Without MAVEN_USER the credentials come from local.properties, so publishing
-# from a workstation works the same way.
-	@if [ -z "${MAVEN_USER}" ]; then \
-		docker run \
-			-i \
-			-v $(pwd):/home/gradle/ \
-			-w /home/gradle/ android-build:android-gradle \
-			make publishDirect; \
-	else \
-		echo "Running CI Publish"; \
-		docker run \
-			-i \
-			-v $(pwd):/home/gradle/ \
-			-e MAVEN_USER \
-			-e MAVEN_PASSWORD \
-			-w /home/gradle/ android-build:android-gradle \
-			make publishDirect; \
-	fi
+# Docker omits an unset variable, so the same target serves CI and a workstation.
+	docker run \
+		-i \
+		-v $(pwd):/home/gradle/ \
+		-e MAVEN_USER \
+		-e MAVEN_PASSWORD \
+		-w /home/gradle/ android-build:android-gradle \
+		make publishDirect
 
 bash: setup
 	docker run \

--- a/makefile
+++ b/makefile
@@ -45,8 +45,6 @@ deployLocal: setup
 		android-build:android-gradle \
 		gradle publishToMavenLocal
 
-# What publishing actually is. CI runs this directly inside the builder
-# container, so the steps stay defined in one place.
 publishDirect:
 	gradle clean
 	gradle assemble


### PR DESCRIPTION
### Motivation

The publish workflow has never succeeded. It moved from a CircleCI VM onto a containerized self-hosted runner. That runner has no `make`. The makefile publish target also wraps `docker run -v $(pwd):/home/gradle/`, which needs a Docker daemon and a host-resolvable workspace path. A container job has neither.

### In this PR
* Run the publish job inside `mobilecoin/android-sdk` as the job container, matching the android-bindings publish job.
* Call gradle through a new `publishDirect` makefile target. The docker-wrapped `publish` target calls it too, so publishing keeps one definition.
* Add `build-docker-dispatch.yaml` to publish that builder image, mirroring android-bindings. It rebuilds on a `docker/**` change to master. Only master moves `:latest`.
* Add `permissions`, a per-tag `concurrency` group, `timeout-minutes`, and an `actionlint` config declaring the two self-hosted runner labels.

Notes:
* `make publishDirect` is verified inside the image on `linux/amd64`. `clean` and `assemble` complete and `publish` reaches the Cloudsmith PUT for `com/mobilecoin/android-sdk/6.1.4/android-sdk-6.1.4.aar`, which is what proves `MAVEN_USER` and `MAVEN_PASSWORD` reach the credentials block.
* A dead or empty Cloudsmith credential fails inside `gradle publish` as an HTTP 401, after `clean` and `assemble` have already run, rather than being caught up front. An earlier revision probed the credential before the build; that step was dropped to keep the job close to the android-bindings shape.
* `mobilecoin/android-sdk` exists on Docker Hub and holds no tags. `build-docker-dispatch.yaml` is not dispatchable until it reaches master, and this branch changes nothing under `docker/**`, so the merge does not build the image on its own.
* A cold `linux/amd64` build of `docker/Dockerfile` takes under a minute on a workstation, so `timeout-minutes: 60` sits far above the real cost.
* The publish job on this branch reaches the runner and fails only on the missing image, so the runner label and the container reference are both good.

### Future Work
* Make tests and publish use the same image
* Close the tag-guard gap on `workflow_dispatch`, and run `actionlint` in CI
