### PR TITLE
fix: scope HTTP Authorization header to configured hosts

### DIFF
--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -28,6 +28,8 @@ import com.mobilecoin.lib.log.LogAdapter;
 import com.mobilecoin.lib.log.Logger;
 import com.mobilecoin.lib.network.NetworkResult;
 import com.mobilecoin.lib.network.TransportProtocol;
+import com.mobilecoin.lib.network.services.http.Requester.HttpRequester;
+import com.mobilecoin.lib.network.services.http.Requester.Requester;
 import com.mobilecoin.lib.network.uri.ConsensusUri;
 import com.mobilecoin.lib.network.uri.FogUri;
 import com.mobilecoin.lib.network.uri.MobileCoinUri;
@@ -160,6 +162,7 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         this.untrustedClient = new FogUntrustedClient(RandomLoadBalancer.create(normalizedFogUri),
             clientConfig.fogLedger, transportProtocol);
         this.txOutStore = createTxOutStore(accountKey);
+        scopeHttpAuthorization(transportProtocol, normalizedFogUri, normalizedConsensusUris);
         this.fogReportsManager = new FogReportsManager(transportProtocol);
         // add client provided log adapter
         LogAdapter logAdapter = clientConfig.logAdapter;
@@ -197,6 +200,34 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
     @NonNull
     FogUntrustedClient getUntrustedClient() {
         return untrustedClient;
+    }
+
+    /**
+     * Limits the HTTP {@code Authorization} header to the hosts this client was configured with.
+     * <p>
+     * Fog report URLs come from the recipient's public address, so {@link ReportClient} contacts a
+     * host the counterparty chose. It shares the caller's {@link Requester}, so without this the
+     * credentials would be sent there too.
+     * <p>
+     * Only the SDK's own {@link HttpRequester} can be scoped. A caller-supplied {@link Requester}
+     * that attaches its own credentials must do its own host checking.
+     */
+    private static void scopeHttpAuthorization(@Nullable TransportProtocol transportProtocol,
+                                               @NonNull FogUri fogUri,
+                                               @NonNull List<MobileCoinUri> consensusUris) {
+        if (null == transportProtocol) {
+            return;
+        }
+        Requester requester = transportProtocol.getHttpRequester();
+        if (!(requester instanceof HttpRequester)) {
+            return;
+        }
+        Set<String> hosts = new HashSet<>();
+        hosts.add(fogUri.getUri().getHost());
+        for (MobileCoinUri consensusUri : consensusUris) {
+            hosts.add(consensusUri.getUri().getHost());
+        }
+        ((HttpRequester) requester).addAuthorizedHosts(hosts);
     }
 
     private List<MobileCoinUri> createNormalizedConsensusUris(List<Uri> consensusUris)

--- a/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java
@@ -162,7 +162,8 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         this.untrustedClient = new FogUntrustedClient(RandomLoadBalancer.create(normalizedFogUri),
             clientConfig.fogLedger, transportProtocol);
         this.txOutStore = createTxOutStore(accountKey);
-        scopeHttpAuthorization(transportProtocol, normalizedFogUri, normalizedConsensusUris);
+        scopeHttpAuthorization(transportProtocol, accountKey, normalizedFogUri,
+                normalizedConsensusUris);
         this.fogReportsManager = new FogReportsManager(transportProtocol);
         // add client provided log adapter
         LogAdapter logAdapter = clientConfig.logAdapter;
@@ -209,12 +210,19 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
      * host the counterparty chose. It shares the caller's {@link Requester}, so without this the
      * credentials would be sent there too.
      * <p>
+     * The account's own fog report host is included: it comes from the caller's own
+     * {@link AccountKey}, not from a counterparty, and {@link #reportUrisFor} fetches it on every
+     * send. It is frequently a different host from the fog view/ledger uri, so leaving it out
+     * would strip the header from the caller's own report fetches.
+     * <p>
      * Only the SDK's own {@link HttpRequester} can be scoped. A caller-supplied {@link Requester}
      * that attaches its own credentials must do its own host checking.
      */
-    private static void scopeHttpAuthorization(@Nullable TransportProtocol transportProtocol,
-                                               @NonNull FogUri fogUri,
-                                               @NonNull List<MobileCoinUri> consensusUris) {
+    @VisibleForTesting
+    static void scopeHttpAuthorization(@Nullable TransportProtocol transportProtocol,
+                                       @NonNull AccountKey accountKey,
+                                       @NonNull FogUri fogUri,
+                                       @NonNull List<MobileCoinUri> consensusUris) {
         if (null == transportProtocol) {
             return;
         }
@@ -224,6 +232,10 @@ public final class MobileCoinClient implements MobileCoinAccountClient, MobileCo
         }
         Set<String> hosts = new HashSet<>();
         hosts.add(fogUri.getUri().getHost());
+        Uri ownReportUri = accountKey.getFogReportUri();
+        if (null != ownReportUri) {
+            hosts.add(ownReportUri.getHost());
+        }
         for (MobileCoinUri consensusUri : consensusUris) {
             hosts.add(consensusUri.getUri().getHost());
         }

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/Requester/HttpRequester.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/Requester/HttpRequester.java
@@ -14,10 +14,14 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * HttpRequester class is used to make a HTTP request and returns the response.
@@ -25,12 +29,49 @@ import java.util.Set;
 
 public class HttpRequester implements Requester {
     private static final String HEADER_CONTENT_TYPE_KEY = "Content-Type";
+    private static final String HEADER_AUTHORIZATION_KEY = "Authorization";
     private final String credentials;
+    private final Set<String> authorizedHosts =
+            Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
 
     public HttpRequester(String username, String password) {
         byte credentialBytes[] = (username + ":" + password).getBytes(StandardCharsets.ISO_8859_1);
         this.credentials = "Basic " + android.util.Base64.encodeToString(credentialBytes, 0);
         password = null;
+    }
+
+    /**
+     * Restricts the {@code Authorization} header to the given hosts.
+     * <p>
+     * Not every host this requester is asked to contact is one the caller configured. Fog report
+     * URLs are taken from the recipient's public address, so a counterparty chooses that host.
+     * {@link com.mobilecoin.lib.MobileCoinClient} calls this with its configured fog and consensus
+     * hosts so that credentials are never sent to a host the counterparty picked.
+     * <p>
+     * Hosts accumulate rather than replace, so one requester may be shared across clients.
+     *
+     * @param hosts hostnames (no scheme, no port) that may receive the credentials
+     */
+    public void addAuthorizedHosts(@NonNull Collection<String> hosts) {
+        for (String host : hosts) {
+            if (host != null && !host.isEmpty()) {
+                authorizedHosts.add(host.toLowerCase(Locale.ROOT));
+            }
+        }
+    }
+
+    /**
+     * ponytail: an un-scoped requester still authenticates to every host, so that callers who
+     * never build a MobileCoinClient keep working. No counterparty-supplied URL can reach such a
+     * requester -- report URLs only flow through MobileCoinClient, which always scopes it.
+     * Tighten to deny-by-default if that stops being true.
+     */
+    private boolean isAuthorizedHost(@NonNull Uri uri) {
+        if (authorizedHosts.isEmpty()) {
+            return true;
+        }
+        String host = uri.getHost();
+        return host != null && authorizedHosts.contains(host.toLowerCase(Locale.ROOT));
     }
 
     /**
@@ -53,7 +94,9 @@ public class HttpRequester implements Requester {
                                     @NonNull Map<String, String> headers,
                                     @NonNull byte[] body,
                                     @NonNull String contentType) throws IOException {
-        headers.put("Authorization", credentials);
+        if (isAuthorizedHost(uri)) {
+            headers.put(HEADER_AUTHORIZATION_KEY, credentials);
+        }
         HttpURLConnection connection = createConnection(httpMethod, uri, headers, body, contentType);
         ByteArrayOutputStream byteArrayOutputStream = parseResponse(connection);
         int responseCode = connection.getResponseCode();

--- a/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/Requester/HttpRequester.java
+++ b/android-sdk/src/main/java/com/mobilecoin/lib/network/services/http/Requester/HttpRequester.java
@@ -94,10 +94,14 @@ public class HttpRequester implements Requester {
                                     @NonNull Map<String, String> headers,
                                     @NonNull byte[] body,
                                     @NonNull String contentType) throws IOException {
+        // Copy: the caller's map outlives this request (RestClient reuses one per service uri),
+        // so writing credentials into it would leave them there for every later request.
+        Map<String, String> requestHeaders = new HashMap<>(headers);
         if (isAuthorizedHost(uri)) {
-            headers.put(HEADER_AUTHORIZATION_KEY, credentials);
+            requestHeaders.put(HEADER_AUTHORIZATION_KEY, credentials);
         }
-        HttpURLConnection connection = createConnection(httpMethod, uri, headers, body, contentType);
+        HttpURLConnection connection =
+                createConnection(httpMethod, uri, requestHeaders, body, contentType);
         ByteArrayOutputStream byteArrayOutputStream = parseResponse(connection);
         int responseCode = connection.getResponseCode();
         return new HttpResponse() {

--- a/android-sdk/src/test/java/com/mobilecoin/lib/MobileCoinClientAuthorizationScopeTest.java
+++ b/android-sdk/src/test/java/com/mobilecoin/lib/MobileCoinClientAuthorizationScopeTest.java
@@ -1,0 +1,104 @@
+// Copyright (c) 2020-2026 MobileCoin. All rights reserved.
+
+package com.mobilecoin.lib;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+import com.mobilecoin.lib.exceptions.InvalidUriException;
+import com.mobilecoin.lib.network.TransportProtocol;
+import com.mobilecoin.lib.network.services.http.Requester.HttpRequester;
+import com.mobilecoin.lib.network.uri.ConsensusUri;
+import com.mobilecoin.lib.network.uri.FogUri;
+import com.mobilecoin.lib.network.uri.MobileCoinUri;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Covers which hosts may receive the HTTP Basic credentials.
+ * <p>
+ * Fog report uris are read from a public address, so a counterparty picks that host. The
+ * credentials must reach only the hosts this client was configured with -- including the account's
+ * own report host, which is regularly a different host from the fog view/ledger uri.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class MobileCoinClientAuthorizationScopeTest {
+
+    private static final String FOG_VIEW_HOST = "fog-view.example.com";
+    private static final String OWN_REPORT_HOST = "fog-report.example.com";
+    private static final String CONSENSUS_HOST = "consensus.example.com";
+
+    @Test
+    public void scopesCredentialsToConfiguredHostsAndOwnReportHost() throws InvalidUriException {
+        CapturingHttpRequester requester = new CapturingHttpRequester();
+
+        MobileCoinClient.scopeHttpAuthorization(
+                TransportProtocol.forHTTP(requester),
+                accountKeyWithReportUri(Uri.parse("fog://" + OWN_REPORT_HOST)),
+                new FogUri("fog://" + FOG_VIEW_HOST),
+                consensusUris(new ConsensusUri("mc://" + CONSENSUS_HOST)));
+
+        // Exact set: anything extra here is a host that would receive the credentials.
+        assertEquals(
+                new HashSet<>(Arrays.asList(FOG_VIEW_HOST, OWN_REPORT_HOST, CONSENSUS_HOST)),
+                requester.capturedHosts);
+    }
+
+    @Test
+    public void toleratesAccountWithoutFogReportUri() throws InvalidUriException {
+        CapturingHttpRequester requester = new CapturingHttpRequester();
+
+        MobileCoinClient.scopeHttpAuthorization(
+                TransportProtocol.forHTTP(requester),
+                accountKeyWithReportUri(null),
+                new FogUri("fog://" + FOG_VIEW_HOST),
+                consensusUris(new ConsensusUri("mc://" + CONSENSUS_HOST)));
+
+        assertEquals(
+                new HashSet<>(Arrays.asList(FOG_VIEW_HOST, CONSENSUS_HOST)),
+                requester.capturedHosts);
+    }
+
+    @NonNull
+    private static AccountKey accountKeyWithReportUri(Uri reportUri) {
+        AccountKey accountKey = mock(AccountKey.class);
+        when(accountKey.getFogReportUri()).thenReturn(reportUri);
+        return accountKey;
+    }
+
+    @NonNull
+    private static List<MobileCoinUri> consensusUris(@NonNull ConsensusUri consensusUri) {
+        return Collections.<MobileCoinUri>singletonList(consensusUri);
+    }
+
+    /**
+     * Captures the allowlist the client hands down, without reaching into HttpRequester's state.
+     */
+    private static final class CapturingHttpRequester extends HttpRequester {
+        private final Set<String> capturedHosts = new HashSet<>();
+
+        CapturingHttpRequester() {
+            super("username", "password");
+        }
+
+        @Override
+        public void addAuthorizedHosts(@NonNull Collection<String> hosts) {
+            capturedHosts.addAll(hosts);
+            super.addAuthorizedHosts(hosts);
+        }
+    }
+}

--- a/android-sdk/src/test/java/com/mobilecoin/lib/network/services/http/Requester/HttpRequesterTest.java
+++ b/android-sdk/src/test/java/com/mobilecoin/lib/network/services/http/Requester/HttpRequesterTest.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -131,19 +132,22 @@ public class HttpRequesterTest {
         when(connection.getInputStream()).thenReturn(new ByteArrayInputStream(response));
         spy.addAuthorizedHosts(Collections.singleton(CONFIGURED_HOST));
 
-        // When the configured host is contacted
-        Map<String, String> configuredHostHeaders = new HashMap<>();
-        spy.httpRequest(METHOD_NAME, uriWithHost(CONFIGURED_HOST), configuredHostHeaders,
-                new byte[]{ }, "");
+        // When the configured host is contacted, and then a host taken from a counterparty's
+        // fog report url
+        Map<String, String> callerHeaders = new HashMap<>();
+        spy.httpRequest(METHOD_NAME, uriWithHost(CONFIGURED_HOST), callerHeaders, new byte[]{ }, "");
+        spy.httpRequest(METHOD_NAME, uriWithHost(COUNTERPARTY_HOST), callerHeaders, new byte[]{ },
+                "");
 
-        // And when a host taken from a counterparty's fog report url is contacted
-        Map<String, String> counterpartyHostHeaders = new HashMap<>();
-        spy.httpRequest(METHOD_NAME, uriWithHost(COUNTERPARTY_HOST), counterpartyHostHeaders,
-                new byte[]{ }, "");
+        // Then only the request to the configured host carries the credentials
+        ArgumentCaptor<Map<String, String>> sentHeaders = ArgumentCaptor.forClass(Map.class);
+        verify(spy, times(2))
+                .createConnection(any(), any(), sentHeaders.capture(), any(), any());
+        assertTrue(sentHeaders.getAllValues().get(0).containsKey(AUTHORIZATION_KEY));
+        assertFalse(sentHeaders.getAllValues().get(1).containsKey(AUTHORIZATION_KEY));
 
-        // Then only the configured host receives the credentials
-        assertTrue(configuredHostHeaders.containsKey(AUTHORIZATION_KEY));
-        assertFalse(counterpartyHostHeaders.containsKey(AUTHORIZATION_KEY));
+        // And the caller's own map is never written to, so credentials cannot outlive the request
+        assertFalse(callerHeaders.containsKey(AUTHORIZATION_KEY));
     }
 
     @NonNull

--- a/android-sdk/src/test/java/com/mobilecoin/lib/network/services/http/Requester/HttpRequesterTest.java
+++ b/android-sdk/src/test/java/com/mobilecoin/lib/network/services/http/Requester/HttpRequesterTest.java
@@ -2,14 +2,19 @@ package com.mobilecoin.lib.network.services.http.Requester;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.net.Uri;
+
+import androidx.annotation.NonNull;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -22,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +47,9 @@ public class HttpRequesterTest {
     private static final String METHOD_NAME = "POST";
     private static final String HEADER_KEY = "set-cookie";
     private static final String HEADER_VALUE = "VIEW=5f174fe74af1675d; path=/";
+    private static final String AUTHORIZATION_KEY = "Authorization";
+    private static final String CONFIGURED_HOST = "fog.test.mobilecoin.com";
+    private static final String COUNTERPARTY_HOST = "attacker.example.com";
 
     @Before
     public void setup() {
@@ -112,6 +121,36 @@ public class HttpRequesterTest {
         Requester.HttpResponse response = spy.httpRequest(METHOD_NAME, uri, new HashMap<>(), new byte[]{ }, "");
         // Then
         verify(connection, times(1)).disconnect();
+    }
+
+    @Test
+    public void authorizationHeaderIsScopedToAuthorizedHosts() throws IOException {
+        // Given a requester scoped to the configured fog host
+        doReturn(connection).when(spy).createConnection(any(), any(), any(), any(), any());
+        when(connection.getResponseCode()).thenReturn(SUCCESS_RESPONSE_CODE);
+        when(connection.getInputStream()).thenReturn(new ByteArrayInputStream(response));
+        spy.addAuthorizedHosts(Collections.singleton(CONFIGURED_HOST));
+
+        // When the configured host is contacted
+        Map<String, String> configuredHostHeaders = new HashMap<>();
+        spy.httpRequest(METHOD_NAME, uriWithHost(CONFIGURED_HOST), configuredHostHeaders,
+                new byte[]{ }, "");
+
+        // And when a host taken from a counterparty's fog report url is contacted
+        Map<String, String> counterpartyHostHeaders = new HashMap<>();
+        spy.httpRequest(METHOD_NAME, uriWithHost(COUNTERPARTY_HOST), counterpartyHostHeaders,
+                new byte[]{ }, "");
+
+        // Then only the configured host receives the credentials
+        assertTrue(configuredHostHeaders.containsKey(AUTHORIZATION_KEY));
+        assertFalse(counterpartyHostHeaders.containsKey(AUTHORIZATION_KEY));
+    }
+
+    @NonNull
+    private static Uri uriWithHost(@NonNull String host) {
+        Uri uri = mock(Uri.class);
+        when(uri.getHost()).thenReturn(host);
+        return uri;
     }
 
     @Test


### PR DESCRIPTION
## Problem

Fog report URLs are read from the recipient's public address, so the host is chosen by the counterparty:

- `FogReportsManager.java#L97-L99` builds a `ReportClient` per counterparty URI
- `RestServiceAPIManager.java#L44-L46` hands that URI the caller's shared `Requester`

So a consumer on `TransportProtocol.forHTTP(new HttpRequester(user, pass))` sends their credentials to whatever host is in an address someone sends them. That wiring is a documented option and is what `MobileCoinClientWithHttpRequesterTest` does.

## Fix

Scope the header to the hosts the client was configured with. `MobileCoinClient` already has the normalized fog and consensus URIs in hand, so it passes them to the requester at construction:

```java
scopeHttpAuthorization(transportProtocol, normalizedFogUri, normalizedConsensusUris);
```

**No consumer code change** — the allowlist is derived from URIs callers already pass in, so existing integrations are fixed on upgrade.

Hosts accumulate rather than replace, so one requester shared across several clients keeps working.